### PR TITLE
chore: add linter to plugin build workflow

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,10 +14,10 @@
         "sourceType": "module"
     },
     "rules": {
-      "no-unused-vars": "off",
+      "no-unused-vars": "warn",
       "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
       "@typescript-eslint/ban-ts-comment": "off",
-      "no-prototype-builtins": "off",
+      "no-prototype-builtins": "warn",
       "@typescript-eslint/no-empty-function": "off"
     } 
   }

--- a/.github/actions/node-cache/action.yml
+++ b/.github/actions/node-cache/action.yml
@@ -1,0 +1,27 @@
+name: 'Node setup and cache'
+description: 'Setup Node.js packages and restore cache'
+
+inputs:
+  node-version:
+    description: 'Node version to use, default to 20'
+    required: true
+    default: '20'
+outputs:
+  cache-hit:
+    description: 'Forward actions/cache cache-hit output'
+    value: ${{ steps.node-cache.outputs.cache-hit }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: ⚙️ Setup node.js ${{ inputs.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: 📦 Cache node modules
+      id: node-cache
+      uses: actions/cache@v4
+      with:
+        path: node_modules
+        key: node-modules-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,34 +1,62 @@
-name: Release Obsidian plugin
+name: Release Obsidian Plugin
+on: [push]
 
-on:
-  push:
-    tags:
-      - "*"
-
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
-  build:
+  node-setup:
+    name: ⚙️ Setup Node.js
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/node-cache
+        id: cache-node-modules
         with:
-          node-version: "18.x"
+          node-version: '20'
+      - run: npm i
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
 
-      - name: Build plugin
-        run: |
-          npm install
-          npm run build
+  run-lint:
+    name: ✅ Linter
+    needs: node-setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/node-cache
+        id: cache-node-modules
+        with:
+          node-version: '20'
 
-      - name: Create release
+      - name: ✅ Run code style linter
+        id: linter
+        run: npm run lint
+
+  release-plugin:
+    name: 📦 Release Obsidian Plugin
+    needs: run-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/node-cache
+        id: cache-node-modules
+        with:
+          node-version: '20'
+      
+      - name: 📗 Build plugin
+        id: build_plugin
+        if: steps.cache-node-modules.outcome == 'success'
+        run: npm run build
+
+      - name: 📦 Create release
+        if: steps.build_plugin.outcome == 'success' && contains(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          tag="${GITHUB_REF#refs/tags/}"
+          tag='${GITHUB_REF#refs/tags/}'
 
-          gh release create "$tag" \
-            --title="$tag" \
+          gh release create '$tag' \
+            --title='$tag' \
             --draft \
             main.js manifest.json styles.css

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Import all your Apple Books highlights to Obsidian.
 
+![GitHub Downloads](https://img.shields.io/github/downloads/bandantonio/obsidian-apple-books-highlights-plugin/total?style=for-the-badge&logo=github&color=573e7a)
+
+
 ## Overview
 
 This plugin aims to be a **fast**, **customizable**, **reliable**, and **up-to-date** solution to import your Apple Books highlights to Obsidian:

--- a/main.ts
+++ b/main.ts
@@ -16,7 +16,7 @@ export default class IBookHighlightsPlugin extends Plugin {
 	settings: IBookHighlightsPluginSettings;
 
 	async onload() {
-		let settings = await this.loadSettings();
+		const settings = await this.loadSettings();
 		
 		if (settings.importOnStart) {
 			await this.importAndSaveHighlights();
@@ -50,6 +50,7 @@ export default class IBookHighlightsPlugin extends Plugin {
 		});
 	}
 
+	//eslint-disable-next-line
 	onunload() { }
 
 	async loadSettings() {
@@ -110,7 +111,8 @@ export default class IBookHighlightsPlugin extends Plugin {
 			if (bookRelatedAnnotations.length > 0) {
 				// Obsidian forbids adding certain characters to the title of a note, so they must be replaced with a dash (-)
 				// | # ^ [] \ / :
-				const normalizedBookTitle = book.ZTITLE.replace(/[|#\^\[\]\\\/:]+/g, ' -');
+				//eslint-disable-next-line
+				const normalizedBookTitle = book.ZTITLE.replace(/[\|\#\^\[\]\\\/\:]+/g, ' -');
 				
 				highlights.push({
 					bookTitle: normalizedBookTitle,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "obsidian-apple-books-highlights-import-plugin",
-	"version": "1.0.0",
+	"name": "obsidian-apple-books-highlights-plugin",
+	"version": "1.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "obsidian-apple-books-highlights-import-plugin",
-			"version": "1.0.0",
+			"name": "obsidian-apple-books-highlights-plugin",
+			"version": "1.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"handlebars": "^4.7.8",
@@ -18,6 +18,7 @@
 				"@typescript-eslint/parser": "5.29.0",
 				"builtin-modules": "3.3.0",
 				"esbuild": "0.17.3",
+				"eslint": "^8.57.0",
 				"obsidian": "latest",
 				"tslib": "2.4.0",
 				"typescript": "4.7.4"
@@ -28,22 +29,21 @@
 			"resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
 			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@codemirror/state": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.0.tgz",
-			"integrity": "sha512-hm8XshYj5Fo30Bb922QX9hXB/bxOAVH+qaqHBzw5TKa72vOeslyGwd4X8M0c1dJ9JqxlaMceOQ8RsL9tC7gU0A==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
+			"integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/@codemirror/view": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.23.0.tgz",
-			"integrity": "sha512-/51px9N4uW8NpuWkyUX+iam5+PM6io2fm+QmRnzwqBy5v/pwGg9T0kILFtYeum8hjuvENtgsGNKluOfqIICmeQ==",
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.24.1.tgz",
+			"integrity": "sha512-sBfP4rniPBRQzNakwuQEqjEuiJDWJyF2kqLLqij4WXRoVwPPJfjx966Eq3F7+OPQxDtMt/Q9MWLoZLWjeveBlg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -409,7 +409,6 @@
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
 			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"eslint-visitor-keys": "^3.3.0"
 			},
@@ -425,7 +424,6 @@
 			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
 			"integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
@@ -435,7 +433,6 @@
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
 			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -455,11 +452,10 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.56.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
-			"integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
+			"version": "8.57.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
@@ -471,14 +467,13 @@
 			"optional": true
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.13",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-			"integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+			"version": "0.11.14",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.1",
-				"debug": "^4.1.1",
+				"@humanwhocodes/object-schema": "^2.0.2",
+				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			},
 			"engines": {
@@ -490,7 +485,6 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=12.22"
 			},
@@ -500,11 +494,10 @@
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
-			"dev": true,
-			"peer": true
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+			"dev": true
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -596,9 +589,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.18.69",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.69.tgz",
-			"integrity": "sha512-AfDKv5fWd9XStaEuqFa6PYcM8FgTqxVMsP4BPk60emeB9YX+pp2P0zZ8nU1BQg8hyPGFrMt7MGMRMis8IrcPyg==",
+			"version": "16.18.86",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.86.tgz",
+			"integrity": "sha512-QMvdZf+ZTSiv7gspwhqbfB7Y5DmbYgCsUnakS8Ul9uRbJQehDKaM7SL+GbcDS003Lh7VK4YlelHsRm9HCv26eA==",
 			"dev": true
 		},
 		"node_modules/@types/tern": {
@@ -798,8 +791,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
 			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/abbrev": {
 			"version": "1.1.1",
@@ -812,7 +804,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
 			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -825,7 +816,6 @@
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
-			"peer": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -872,7 +862,6 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -898,7 +887,6 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -932,8 +920,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
@@ -1078,7 +1065,6 @@
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -1088,7 +1074,6 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -1122,7 +1107,6 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -1134,8 +1118,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/color-support": {
 			"version": "1.1.3",
@@ -1163,7 +1146,6 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -1216,8 +1198,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/delegates": {
 			"version": "1.0.0",
@@ -1250,7 +1231,6 @@
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -1338,7 +1318,6 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -1347,17 +1326,16 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.56.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
-			"integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
+			"version": "8.57.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
 				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.56.0",
-				"@humanwhocodes/config-array": "^0.11.13",
+				"@eslint/js": "8.57.0",
+				"@humanwhocodes/config-array": "^0.11.14",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"@ungap/structured-clone": "^1.2.0",
@@ -1459,7 +1437,6 @@
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
 			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -1476,7 +1453,6 @@
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -1486,7 +1462,6 @@
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
 			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
@@ -1504,7 +1479,6 @@
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
 			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -1517,7 +1491,6 @@
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -1557,7 +1530,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1574,8 +1546,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.2",
@@ -1609,20 +1580,18 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/fastq": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
-			"integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
 			"dev": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -1633,7 +1602,6 @@
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"flat-cache": "^3.0.4"
 			},
@@ -1663,7 +1631,6 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -1680,7 +1647,6 @@
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
 			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"flatted": "^3.2.9",
 				"keyv": "^4.5.3",
@@ -1691,11 +1657,10 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.9",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
-			"dev": true,
-			"peer": true
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+			"dev": true
 		},
 		"node_modules/fs-constants": {
 			"version": "1.0.0",
@@ -1774,7 +1739,6 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -1787,7 +1751,6 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
 			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
 			},
@@ -1828,8 +1791,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/handlebars": {
 			"version": "4.7.8",
@@ -1856,7 +1818,6 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1941,9 +1902,9 @@
 			]
 		},
 		"node_modules/ignore": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
-			"integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
@@ -1954,7 +1915,6 @@
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -2010,11 +1970,18 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
 		},
-		"node_modules/ip": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-			"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-			"optional": true
+		"node_modules/ip-address": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+			"optional": true,
+			"dependencies": {
+				"jsbn": "1.1.0",
+				"sprintf-js": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
@@ -2066,7 +2033,6 @@
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2082,7 +2048,6 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -2090,33 +2055,35 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/jsbn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+			"optional": true
+		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
 			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}
@@ -2126,7 +2093,6 @@
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -2140,7 +2106,6 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -2155,8 +2120,7 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
@@ -2377,8 +2341,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/negotiator": {
 			"version": "0.6.3",
@@ -2395,9 +2358,9 @@
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
 		},
 		"node_modules/node-abi": {
-			"version": "3.54.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.54.0.tgz",
-			"integrity": "sha512-p7eGEiQil0YUV3ItH4/tBb781L5impVmmx2E9FRKF7d18XXzp4PGT2tdYMFY6wQqgxD0IwNZOiSJ0/K0fSi/OA==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.56.0.tgz",
+			"integrity": "sha512-fZjdhDOeRcaS+rcpve7XuwHBmktS1nS1gzgghwKUQQ8nTy2FdSDr6ZT8k6YhvlJeHmmQMYiT/IH9hfco5zeW2Q==",
 			"dependencies": {
 				"semver": "^7.3.5"
 			},
@@ -2406,9 +2369,12 @@
 			}
 		},
 		"node_modules/node-addon-api": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
-			"integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA=="
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+			"integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+			"engines": {
+				"node": "^16 || ^18 || >= 20"
+			}
 		},
 		"node_modules/node-gyp": {
 			"version": "8.4.1",
@@ -2465,9 +2431,9 @@
 			}
 		},
 		"node_modules/obsidian": {
-			"version": "1.4.11",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.4.11.tgz",
-			"integrity": "sha512-BCVYTvaXxElJMl6MMbDdY/CGK+aq18SdtDY/7vH8v6BxCBQ6KF4kKxL0vG9UZ0o5qh139KpUoJHNm+6O5dllKA==",
+			"version": "1.5.7-1",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.5.7-1.tgz",
+			"integrity": "sha512-T5ZRuQ1FnfXqEoakTTHVDYvzUEEoT8zSPnQCW31PVgYwG4D4tZCQfKHN2hTz1ifnCe8upvwa6mBTAP2WUA5Vng==",
 			"dev": true,
 			"dependencies": {
 				"@types/codemirror": "5.60.8",
@@ -2491,7 +2457,6 @@
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
 			"integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@aashutoshrathi/word-wrap": "^1.2.3",
 				"deep-is": "^0.1.3",
@@ -2509,7 +2474,6 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -2525,7 +2489,6 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -2556,7 +2519,6 @@
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
@@ -2569,7 +2531,6 @@
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2588,7 +2549,6 @@
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2615,9 +2575,9 @@
 			}
 		},
 		"node_modules/prebuild-install": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-			"integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+			"integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
 			"dependencies": {
 				"detect-libc": "^2.0.0",
 				"expand-template": "^2.0.3",
@@ -2644,7 +2604,6 @@
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -2682,7 +2641,6 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2759,7 +2717,6 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -2847,9 +2804,9 @@
 			"optional": true
 		},
 		"node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -2871,7 +2828,6 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -2884,7 +2840,6 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2958,16 +2913,16 @@
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-			"integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.1.tgz",
+			"integrity": "sha512-B6w7tkwNid7ToxjZ08rQMT8M9BJAf8DKx8Ft4NivzH0zBUfd6jldGcisJn/RLgxcX3FPNDdNQCUEMMT79b+oCQ==",
 			"optional": true,
 			"dependencies": {
-				"ip": "^2.0.0",
+				"ip-address": "^9.0.5",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
-				"node": ">= 10.13.0",
+				"node": ">= 10.0.0",
 				"npm": ">= 3.0.0"
 			}
 		},
@@ -2993,10 +2948,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"optional": true
+		},
 		"node_modules/sqlite3": {
-			"version": "5.1.7-rc.0",
-			"resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7-rc.0.tgz",
-			"integrity": "sha512-LBbru2WM4I259E+1pernw/vYKMjQa5elvxJPC15/7TgWYAaOBXuTnamyXdWJh7EH0qmhQrPmYEI9PbCMdoAW9Q==",
+			"version": "5.1.7",
+			"resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
+			"integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"bindings": "^1.5.0",
@@ -3067,7 +3028,6 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -3076,9 +3036,9 @@
 			}
 		},
 		"node_modules/style-mod": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.0.tgz",
-			"integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
 			"dev": true,
 			"peer": true
 		},
@@ -3087,7 +3047,6 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -3154,8 +3113,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -3212,7 +3170,6 @@
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -3225,7 +3182,6 @@
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -3281,7 +3237,6 @@
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -3342,7 +3297,6 @@
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -3356,20 +3310,19 @@
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
 			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@codemirror/state": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.0.tgz",
-			"integrity": "sha512-hm8XshYj5Fo30Bb922QX9hXB/bxOAVH+qaqHBzw5TKa72vOeslyGwd4X8M0c1dJ9JqxlaMceOQ8RsL9tC7gU0A==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
+			"integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==",
 			"dev": true,
 			"peer": true
 		},
 		"@codemirror/view": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.23.0.tgz",
-			"integrity": "sha512-/51px9N4uW8NpuWkyUX+iam5+PM6io2fm+QmRnzwqBy5v/pwGg9T0kILFtYeum8hjuvENtgsGNKluOfqIICmeQ==",
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.24.1.tgz",
+			"integrity": "sha512-sBfP4rniPBRQzNakwuQEqjEuiJDWJyF2kqLLqij4WXRoVwPPJfjx966Eq3F7+OPQxDtMt/Q9MWLoZLWjeveBlg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -3537,7 +3490,6 @@
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
 			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"eslint-visitor-keys": "^3.3.0"
 			}
@@ -3546,15 +3498,13 @@
 			"version": "4.10.0",
 			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
 			"integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@eslint/eslintrc": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
 			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -3568,11 +3518,10 @@
 			}
 		},
 		"@eslint/js": {
-			"version": "8.56.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
-			"integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
-			"dev": true,
-			"peer": true
+			"version": "8.57.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+			"dev": true
 		},
 		"@gar/promisify": {
 			"version": "1.1.3",
@@ -3581,14 +3530,13 @@
 			"optional": true
 		},
 		"@humanwhocodes/config-array": {
-			"version": "0.11.13",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-			"integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+			"version": "0.11.14",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
-				"@humanwhocodes/object-schema": "^2.0.1",
-				"debug": "^4.1.1",
+				"@humanwhocodes/object-schema": "^2.0.2",
+				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			}
 		},
@@ -3596,15 +3544,13 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@humanwhocodes/object-schema": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
-			"dev": true,
-			"peer": true
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+			"dev": true
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -3680,9 +3626,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "16.18.69",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.69.tgz",
-			"integrity": "sha512-AfDKv5fWd9XStaEuqFa6PYcM8FgTqxVMsP4BPk60emeB9YX+pp2P0zZ8nU1BQg8hyPGFrMt7MGMRMis8IrcPyg==",
+			"version": "16.18.86",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.86.tgz",
+			"integrity": "sha512-QMvdZf+ZTSiv7gspwhqbfB7Y5DmbYgCsUnakS8Ul9uRbJQehDKaM7SL+GbcDS003Lh7VK4YlelHsRm9HCv26eA==",
 			"dev": true
 		},
 		"@types/tern": {
@@ -3793,8 +3739,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
 			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"abbrev": {
 			"version": "1.1.1",
@@ -3806,15 +3751,13 @@
 			"version": "8.11.3",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
 			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {}
 		},
 		"agent-base": {
@@ -3850,7 +3793,6 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -3869,7 +3811,6 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
@@ -3894,8 +3835,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"array-union": {
 			"version": "2.1.0",
@@ -3996,15 +3936,13 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -4026,7 +3964,6 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"color-name": "~1.1.4"
 			}
@@ -4035,8 +3972,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"color-support": {
 			"version": "1.1.3",
@@ -4061,7 +3997,6 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -4094,8 +4029,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"delegates": {
 			"version": "1.0.0",
@@ -4122,7 +4056,6 @@
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"esutils": "^2.0.2"
 			}
@@ -4196,21 +4129,19 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"eslint": {
-			"version": "8.56.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
-			"integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
+			"version": "8.57.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
 				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.56.0",
-				"@humanwhocodes/config-array": "^0.11.13",
+				"@eslint/js": "8.57.0",
+				"@humanwhocodes/config-array": "^0.11.14",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"@ungap/structured-clone": "^1.2.0",
@@ -4251,7 +4182,6 @@
 					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
 					"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"esrecurse": "^4.3.0",
 						"estraverse": "^5.2.0"
@@ -4261,8 +4191,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				}
 			}
 		},
@@ -4304,7 +4233,6 @@
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
 			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"acorn": "^8.9.0",
 				"acorn-jsx": "^5.3.2",
@@ -4316,7 +4244,6 @@
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
 			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"estraverse": "^5.1.0"
 			},
@@ -4325,8 +4252,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				}
 			}
 		},
@@ -4357,8 +4283,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"expand-template": {
 			"version": "2.0.3",
@@ -4369,8 +4294,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"fast-glob": {
 			"version": "3.3.2",
@@ -4400,20 +4324,18 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"fastq": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
-			"integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
@@ -4424,7 +4346,6 @@
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"flat-cache": "^3.0.4"
 			}
@@ -4448,7 +4369,6 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -4459,7 +4379,6 @@
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
 			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"flatted": "^3.2.9",
 				"keyv": "^4.5.3",
@@ -4467,11 +4386,10 @@
 			}
 		},
 		"flatted": {
-			"version": "3.2.9",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
-			"dev": true,
-			"peer": true
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+			"dev": true
 		},
 		"fs-constants": {
 			"version": "1.0.0",
@@ -4538,7 +4456,6 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"is-glob": "^4.0.3"
 			}
@@ -4548,7 +4465,6 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
 			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"type-fest": "^0.20.2"
 			}
@@ -4577,8 +4493,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"handlebars": {
 			"version": "4.7.8",
@@ -4596,8 +4511,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"has-unicode": {
 			"version": "2.0.1",
@@ -4656,9 +4570,9 @@
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
 		},
 		"ignore": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
-			"integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
 			"dev": true
 		},
 		"import-fresh": {
@@ -4666,7 +4580,6 @@
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -4710,11 +4623,15 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
 		},
-		"ip": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-			"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-			"optional": true
+		"ip-address": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+			"optional": true,
+			"requires": {
+				"jsbn": "1.1.0",
+				"sprintf-js": "^1.1.3"
+			}
 		},
 		"is-extglob": {
 			"version": "2.1.1",
@@ -4753,8 +4670,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -4767,38 +4683,39 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"argparse": "^2.0.1"
 			}
+		},
+		"jsbn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+			"optional": true
 		},
 		"json-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
 			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"json-buffer": "3.0.1"
 			}
@@ -4808,7 +4725,6 @@
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -4819,7 +4735,6 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"p-locate": "^5.0.0"
 			}
@@ -4828,8 +4743,7 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"lru-cache": {
 			"version": "6.0.0",
@@ -4994,8 +4908,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"negotiator": {
 			"version": "0.6.3",
@@ -5009,17 +4922,17 @@
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
 		},
 		"node-abi": {
-			"version": "3.54.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.54.0.tgz",
-			"integrity": "sha512-p7eGEiQil0YUV3ItH4/tBb781L5impVmmx2E9FRKF7d18XXzp4PGT2tdYMFY6wQqgxD0IwNZOiSJ0/K0fSi/OA==",
+			"version": "3.56.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.56.0.tgz",
+			"integrity": "sha512-fZjdhDOeRcaS+rcpve7XuwHBmktS1nS1gzgghwKUQQ8nTy2FdSDr6ZT8k6YhvlJeHmmQMYiT/IH9hfco5zeW2Q==",
 			"requires": {
 				"semver": "^7.3.5"
 			}
 		},
 		"node-addon-api": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
-			"integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA=="
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+			"integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g=="
 		},
 		"node-gyp": {
 			"version": "8.4.1",
@@ -5061,9 +4974,9 @@
 			}
 		},
 		"obsidian": {
-			"version": "1.4.11",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.4.11.tgz",
-			"integrity": "sha512-BCVYTvaXxElJMl6MMbDdY/CGK+aq18SdtDY/7vH8v6BxCBQ6KF4kKxL0vG9UZ0o5qh139KpUoJHNm+6O5dllKA==",
+			"version": "1.5.7-1",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.5.7-1.tgz",
+			"integrity": "sha512-T5ZRuQ1FnfXqEoakTTHVDYvzUEEoT8zSPnQCW31PVgYwG4D4tZCQfKHN2hTz1ifnCe8upvwa6mBTAP2WUA5Vng==",
 			"dev": true,
 			"requires": {
 				"@types/codemirror": "5.60.8",
@@ -5083,7 +4996,6 @@
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
 			"integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@aashutoshrathi/word-wrap": "^1.2.3",
 				"deep-is": "^0.1.3",
@@ -5098,7 +5010,6 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"yocto-queue": "^0.1.0"
 			}
@@ -5108,7 +5019,6 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"p-limit": "^3.0.2"
 			}
@@ -5127,7 +5037,6 @@
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"callsites": "^3.0.0"
 			}
@@ -5136,8 +5045,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -5149,8 +5057,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"path-type": {
 			"version": "4.0.0",
@@ -5165,9 +5072,9 @@
 			"dev": true
 		},
 		"prebuild-install": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-			"integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+			"integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
 			"requires": {
 				"detect-libc": "^2.0.0",
 				"expand-template": "^2.0.3",
@@ -5187,8 +5094,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
@@ -5219,8 +5125,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"queue-microtask": {
 			"version": "1.2.3",
@@ -5266,8 +5171,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"retry": {
 			"version": "0.12.0",
@@ -5311,9 +5215,9 @@
 			"optional": true
 		},
 		"semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}
@@ -5329,7 +5233,6 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"shebang-regex": "^3.0.0"
 			}
@@ -5338,8 +5241,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.7",
@@ -5375,12 +5277,12 @@
 			"optional": true
 		},
 		"socks": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-			"integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.1.tgz",
+			"integrity": "sha512-B6w7tkwNid7ToxjZ08rQMT8M9BJAf8DKx8Ft4NivzH0zBUfd6jldGcisJn/RLgxcX3FPNDdNQCUEMMT79b+oCQ==",
 			"optional": true,
 			"requires": {
-				"ip": "^2.0.0",
+				"ip-address": "^9.0.5",
 				"smart-buffer": "^4.2.0"
 			}
 		},
@@ -5400,10 +5302,16 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 		},
+		"sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"optional": true
+		},
 		"sqlite3": {
-			"version": "5.1.7-rc.0",
-			"resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7-rc.0.tgz",
-			"integrity": "sha512-LBbru2WM4I259E+1pernw/vYKMjQa5elvxJPC15/7TgWYAaOBXuTnamyXdWJh7EH0qmhQrPmYEI9PbCMdoAW9Q==",
+			"version": "5.1.7",
+			"resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
+			"integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
 			"requires": {
 				"bindings": "^1.5.0",
 				"node-addon-api": "^7.0.0",
@@ -5453,13 +5361,12 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"style-mod": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.0.tgz",
-			"integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
 			"dev": true,
 			"peer": true
 		},
@@ -5468,7 +5375,6 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"has-flag": "^4.0.0"
 			}
@@ -5527,8 +5433,7 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"to-regex-range": {
 			"version": "5.0.1",
@@ -5575,7 +5480,6 @@
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"prelude-ls": "^1.2.1"
 			}
@@ -5584,8 +5488,7 @@
 			"version": "0.20.2",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"typescript": {
 			"version": "4.7.4",
@@ -5622,7 +5525,6 @@
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -5676,8 +5578,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+		"lint": "eslint . --ext .ts",
 		"version": "node version-bump.mjs"
 	},
 	"keywords": [
@@ -31,6 +32,7 @@
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
 		"esbuild": "0.17.3",
+		"eslint": "^8.57.0",
 		"obsidian": "latest",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,4 +1,4 @@
-import { App, Notice, SuggestModal } from 'obsidian';
+import { App, SuggestModal } from 'obsidian';
 import IBookHighlightsPlugin from '../main';
 import { CombinedHighlight } from './types';
 
@@ -28,6 +28,7 @@ export class IBookHighlightsPluginSearchModal extends IBookHighlightsPluginSugge
         el.createEl('small', { text: value.bookAuthor });
     }
 
+    //eslint-disable-next-line
     onChooseSuggestion(item: CombinedHighlight, event: MouseEvent | KeyboardEvent) {
         this.plugin.saveHighlightsToVault([item]);
         

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -68,7 +68,7 @@ class IBookHighlightsSettingTab extends PluginSettingTab {
                     .setPlaceholder('Template')
                     .setValue(this.plugin.settings.template)
                     .onChange(async (value) => {
-                        let valueToSet = (value === '') ? defaultTemplate : value;
+                        const valueToSet = (value === '') ? defaultTemplate : value;
                         this.plugin.settings.template = valueToSet;
                         await this.plugin.saveSettings();
                     });


### PR DESCRIPTION
This update includes the following changes:

- Add eslint to the workflow
- Refactor workflow to add linter as a blocking check before compiling plugin code
- Add workflow step with cached node dependencies to speed up the build process