### PR TITLE
fix: remove new lines around colored highlight blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,13 @@ Number of annotations:: {{annotations.length}}
 
 - 📖 Chapter:: {{#if chapter}}{{{chapter}}}{{else}}N/A{{/if}}
 - 🔖 Context:: {{#if contextualText}}{{{contextualText}}}{{else}}N/A{{/if}}
-{{#if (eq highlightStyle "0")}}- 🎯 Highlight:: <u>{{{highlight}}}</u>{{/if}}
-{{#if (eq highlightStyle "1")}}- 🎯 Highlight:: <mark style="background:rgb(175,213,151); color:#000; padding:2px;">{{{highlight}}}</mark>{{/if}}
-{{#if (eq highlightStyle "2")}}- 🎯 Highlight:: <mark style="background:rgb(181,205,238); color:#000; padding:2px;">{{{highlight}}}</mark>{{/if}}
-{{#if (eq highlightStyle "3")}}- 🎯 Highlight:: <mark style="background:rgb(249,213,108); color:#000; padding:2px;">{{{highlight}}}</mark>{{/if}}
-{{#if (eq highlightStyle "4")}}- 🎯 Highlight:: <mark style="background:rgb(242,178,188); color:#000; padding:2px;">{{{highlight}}}</mark>{{/if}}
-{{#if (eq highlightStyle "5")}}- 🎯 Highlight:: <mark style="background:rgb(214,192,238); color:#000; padding:2px;">{{{highlight}}}</mark>{{/if}}
+{{#if (eq highlightStyle "0")}}- 🎯 Highlight:: <u>{{{highlight}}}</u>
+{{else if (eq highlightStyle "1")}}- 🎯 Highlight:: <mark style="background:rgb(175,213,151); color:#000; padding:2px;">{{{highlight}}}</mark>
+{{else if (eq highlightStyle "2")}}- 🎯 Highlight:: <mark style="background:rgb(181,205,238); color:#000; padding:2px;">{{{highlight}}}</mark>
+{{else if (eq highlightStyle "3")}}- 🎯 Highlight:: <mark style="background:rgb(249,213,108); color:#000; padding:2px;">{{{highlight}}}</mark>
+{{else if (eq highlightStyle "4")}}- 🎯 Highlight:: <mark style="background:rgb(242,178,188); color:#000; padding:2px;">{{{highlight}}}</mark>
+{{else if (eq highlightStyle "5")}}- 🎯 Highlight:: <mark style="background:rgb(214,192,238); color:#000; padding:2px;">{{{highlight}}}</mark>
+{{/if}}
 - 📝 Note:: {{#if note}}{{{note}}}{{else}}N/A{{/if}}
 - <small>📅 Highlight taken on:: {{dateFormat highlightCreationDate "YYYY-MM-DD hh:mm:ss A Z"}}</small>
 - <small>📅 Highlight modified on:: {{dateFormat highlightModificationDate "YYYY-MM-DD hh:mm:ss A Z"}}</small>


### PR DESCRIPTION
**Summary**

This removes the new lines that appear above and beneath colored highlight blocks in Obsidian's editing mode by updating the template inside the README to match the template used in `rawTemplates.ts`

Before:
<img width="2160" alt="colored-highlights-newline-bug-before" src="https://github.com/bandantonio/obsidian-apple-books-highlights-plugin/assets/19255312/4bbbc272-5787-4815-9622-1e35d8d34e66">

After: 
<img width="2160" alt="colored-highlights-newline-bug-after" src="https://github.com/bandantonio/obsidian-apple-books-highlights-plugin/assets/19255312/c444b0bc-9ef8-4319-9eeb-5c634a7585be">
