### PR TITLE
fix: rename file on duplicate books.

### DIFF
--- a/src/methods/saveHighlightsToVault.ts
+++ b/src/methods/saveHighlightsToVault.ts
@@ -90,9 +90,23 @@ export default class SaveHighlights {
 	}
 
 	async createNewBookFile(filePath: string, data: string): Promise<void> {
-		await this.vault.create(
-			filePath,
-			data
-		);
+		let finalPath = filePath;
+		let counter = 1;
+		let hasWarned = false;
+
+		while (this.vault.getAbstractFileByPath(finalPath)) {
+			if (!hasWarned) {
+				console.warn(`File "${filePath}" already exists. Renaming to avoid overwrite.`);
+				hasWarned = true;
+			}
+			// Extract file extension (e.g., ".md") if present
+			const ext = filePath.includes('.') ? '.' + filePath.split('.').pop() : '';
+			// Remove the extension from the original file path to get the base name
+			const baseName = filePath.replace(new RegExp(`${ext}$`), '');
+			// Generate a new file name with a counter suffix, e.g., "Notes (1).md"
+			finalPath = `${baseName} (${counter})${ext}`;
+			counter++;
+		}
+		await this.vault.create(finalPath, data);
 	}
 }

--- a/test/saveHighlightsToVault.spec.ts
+++ b/test/saveHighlightsToVault.spec.ts
@@ -17,6 +17,7 @@ import { ICombinedBooksAndHighlights } from '../src/types'
 const mockVault = {
 	getFileByPath: vi.fn(),
 	getFolderByPath: vi.fn(),
+	getAbstractFileByPath: vi.fn(),
 	// eslint-disable-next-line
 	createFolder: vi.fn().mockImplementation(async (folderName: string) => {
 		return;
@@ -61,6 +62,7 @@ describe('Save all highlights to vault', () => {
 		// eslint-disable-next-line
 		const saveHighlights = new SaveHighlights({ vault: mockVault } as any, settings);
 		const spyGetFolderByPath = vi.spyOn(mockVault, 'getFolderByPath').mockReturnValue('ibooks-highlights');
+		vi.spyOn(mockVault, 'getAbstractFileByPath').mockImplementation(() => undefined);
 
 		await saveHighlights.saveAllBooksHighlightsToVault(aggregatedUnsortedHighlights as ICombinedBooksAndHighlights[]);
 
@@ -76,6 +78,23 @@ describe('Save all highlights to vault', () => {
 		expect(mockVault.create).toHaveBeenCalledTimes(1);
 		expect(mockVault.create).toHaveBeenCalledWith(
 			`ibooks-highlights/Apple iPhone - User Guide - Instructions - with - restricted - symbols - in - title.md`,
+			defaultTemplateMockWithAnnotationsSortedByDefault
+		);
+	});
+
+	test('Should rename file if it already exists', async () => {
+		const saveHighlights = new SaveHighlights({ vault: mockVault } as any, settings);
+		vi.spyOn(mockVault, 'getFolderByPath').mockReturnValue('ibooks-highlights');
+		let callCount = 0;
+		vi.spyOn(mockVault, 'getAbstractFileByPath').mockImplementation(() => {
+			callCount++;
+			return callCount === 1 ? {} : undefined;
+		});
+
+		await saveHighlights.saveAllBooksHighlightsToVault(aggregatedUnsortedHighlights as ICombinedBooksAndHighlights[]);
+
+		expect(mockVault.create).toHaveBeenCalledWith(
+			`ibooks-highlights/Apple iPhone - User Guide - Instructions - with - restricted - symbols - in - title (1).md`,
 			defaultTemplateMockWithAnnotationsSortedByDefault
 		);
 	});


### PR DESCRIPTION
# Description

Fixes #54 

Rename output file if book name is duplicated

<img width="999" height="98" alt="image" src="https://github.com/user-attachments/assets/9aa549ab-ddc8-491b-b8f8-14cff3b35f49" />

## Test
I've added a new test to test this change, it looks good:
```
 Test Files  13 passed | 1 skipped (14)
      Tests  79 passed | 4 todo (83)
   Start at  22:53:42
   Duration  885ms (transform 1.50s, setup 0ms, collect 2.62s, tests 501ms, environment 2ms, prepare 1.19s)

```


BTW, I love this indent style:
```
indent_style = tab
indent_size = 4
tab_width = 4
```

# Checklist

- [x] I accept the [Code of Conduct](https://github.com/bandantonio/obsidian-apple-books-highlights-plugin/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I have performed a self-review of my code for consistency and potential leftover debug logs, commented out code, etc.
- [x] I have added tests that prove that my feature works or that the fix is effective
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if necessary)
- [x] I confirm that this PR DOESN'T change the plugin's version either in the `manifest.json` or `package.json` files
- [x] I have checked that my commit messages are descriptive and follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] I have enabled the checkbox to allow maintainer edits so the branch can be updated for a merge.
