### PR TITLE
chore: switch release creation flow to github cli. Add release notes template

### DIFF
--- a/.github/release_notes_template.md
+++ b/.github/release_notes_template.md
@@ -1,0 +1,17 @@
+## What's new
+
+### Feature Update Description
+
+Description of the feature update goes here. This should be a concise summary of the changes made in this release.
+
+[Link to the documentation](https://mister-gold.pro/obsidian-apple-books-highlights-plugin/)
+
+## Bug Fixes
+
+* Description of the bug fix goes here. This should detail the issue that was resolved in this release.
+
+## New contributors
+
+* Name of the new contributor (`@username`) goes here.
+
+----

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,9 +72,15 @@ jobs:
         run: npm run build
 
       - name: 📦 Create release
-        uses: softprops/action-gh-release@v1
         if: steps.build_plugin.outcome == 'success' && contains(github.ref, 'refs/tags/')
-        with:
-          body: 'This release was generated automatically. Full details will be available soon'
-          draft: true
-          files: './dist/*'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          gh release create "$TAG_NAME" \
+            --verify-tag \
+            --draft \
+            --title "$TAG_NAME" \
+            --generate-notes \
+            --notes-file .github/release_notes_template.md \
+            ./dist/*


### PR DESCRIPTION
## Description
Maintenance update that improves the automated plugin release creation flow by switching from a third-party action to GitHub CLI. 
