### PR TITLE
chore: remove husky in favor of using git hooks directly

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,0 +1,2 @@
+npm run lint
+npm test -- --no-watch

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,0 @@
-npm run lint
-npm test -- --no-watch

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "obsidian-apple-books-highlights-plugin",
 			"version": "1.6.0",
+			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"dayjs": "^1.11.13",
@@ -22,7 +23,6 @@
 				"drizzle-kit": "^0.31.4",
 				"drizzle-orm": "^0.44.4",
 				"esbuild": "0.25.9",
-				"husky": "^9.1.7",
 				"obsidian": "latest",
 				"tslib": "2.8.1",
 				"typescript": "5.9.2",
@@ -3455,22 +3455,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/husky": {
-			"version": "9.1.7",
-			"resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-			"integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"husky": "bin.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/typicode"
 			}
 		},
 		"node_modules/ieee754": {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
 		"coverage": "vitest run --coverage",
 		"db:generate": "drizzle-kit generate:sqlite",
 		"db:migrate": "npx tsx src/db/migrate.ts",
-		"db:seed": "npx tsx src/db/seed.ts",
-		"prepare": "husky",
+    "db:seed": "npx tsx src/db/seed.ts",
 		"docs:dev": "vitepress dev docs --port 3000",
 		"docs:build": "vitepress build docs",
-		"docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs",
+    "setup:git-hooks": "git config core.hooksPath .git-hooks",
+    "postinstall": "npm run setup:git-hooks"
 	},
 	"keywords": [
 		"obsidian",
@@ -53,7 +54,6 @@
     "drizzle-kit": "^0.31.4",
     "drizzle-orm": "^0.44.4",
     "esbuild": "0.25.9",
-    "husky": "^9.1.7",
 		"obsidian": "latest",
     "tslib": "2.8.1",
     "typescript": "5.9.2",


### PR DESCRIPTION
# Description

Replaced husky package dependency with 'native' git hooks

# Checklist

- [x] I accept the [Code of Conduct](https://github.com/bandantonio/obsidian-apple-books-highlights-plugin/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I have performed a self-review of my code for consistency and potential leftover debug logs, commented out code, etc.
- [x] I have added tests that prove that my feature works or that the fix is effective
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if necessary)
- [x] I confirm that this PR DOESN'T change the plugin's version either in the `manifest.json` or `package.json` files
- [x] I have checked that my commit messages are descriptive and follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] I have enabled the checkbox to allow maintainer edits so the branch can be updated for a merge.
