### PR TITLE
fix: update checkBookExistence and backupHighlights to use file name template instead of raw book title to solve errors on re-import

### DIFF
--- a/src/methods/saveHighlightsToVault.ts
+++ b/src/methods/saveHighlightsToVault.ts
@@ -76,7 +76,7 @@ export default class SaveHighlights {
         const vaultFile = this.vault.getFileByPath(filePath) as TFile;
 
         if (isBackupEnabled) {
-          backupMethods.backupSingleBookHighlights(combinedHighlight.bookTitle);
+          backupMethods.backupSingleBookHighlights(renderedFilenameTemplate);
         }
 
         await this.modifyExistingBookFile(vaultFile, renderedTemplate);

--- a/src/search.ts
+++ b/src/search.ts
@@ -36,7 +36,7 @@ export class IBookHighlightsPluginSearchModal extends IBookHighlightsPluginSugge
   }
 
   async onChooseSuggestion(item: ICombinedBooksAndHighlights) {
-    const doesBookFileExist = checkBookExistence(item.bookTitle, this.app.vault, this.plugin.settings);
+    const doesBookFileExist = await checkBookExistence(item, this.app.vault, this.plugin.settings);
 
     const isBackupEnabled = this.plugin.settings.backup;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-import type { Template } from 'handlebars';
-
 export interface IBook {
   ZASSETID: string;
   ZTITLE: string;
@@ -58,5 +56,6 @@ export interface IBookHighlightsPluginSettings {
   backup: boolean;
   importOnStart: boolean;
   highlightsSortingCriterion: IHighlightsSortingCriterion;
-  template: Template;
+  template: string;
+  filenameTemplate: string;
 }

--- a/src/utils/backupHighlights.ts
+++ b/src/utils/backupHighlights.ts
@@ -1,4 +1,4 @@
-import type { TFile, Vault } from 'obsidian';
+import type { Vault } from 'obsidian';
 import path from 'path';
 import type { AppleBooksHighlightsImportPluginSettings } from '../settings';
 
@@ -40,11 +40,16 @@ export default class BackupHighlights {
     }
   }
 
-  async backupSingleBookHighlights(bookTitle: string): Promise<void> {
-    const bookFilePathToBackup = path.join(this.settings.highlightsFolder, `${bookTitle}.md`);
-    const vaultFile = this.vault.getFileByPath(bookFilePathToBackup) as TFile;
+  async backupSingleBookHighlights(filename: string): Promise<void> {
+    const bookFilePathToBackup = path.join(this.settings.highlightsFolder, `${filename}.md`);
+    const vaultFile = this.vault.getFileByPath(bookFilePathToBackup);
 
-    const backupBookTitle = `${bookTitle}-bk-${Date.now()}.md`;
+    // File may not exist in case when the user changed the filename template between imports of the same book
+    if (!vaultFile) {
+      return;
+    }
+
+    const backupBookTitle = `${filename}-bk-${Date.now()}.md`;
 
     await this.vault.adapter.copy(vaultFile.path, path.join(this.settings.highlightsFolder, backupBookTitle));
   }

--- a/src/utils/checkBookExistence.ts
+++ b/src/utils/checkBookExistence.ts
@@ -1,9 +1,16 @@
 import type { Vault } from 'obsidian';
 import path from 'path';
+import { renderHighlightsTemplate } from '../methods/renderHighlightsTemplate';
 import type { AppleBooksHighlightsImportPluginSettings } from '../settings';
+import type { ICombinedBooksAndHighlights } from '../types';
 
-export const checkBookExistence = (bookTitle: string, vault: Vault, settings: AppleBooksHighlightsImportPluginSettings): boolean => {
-  const pathToBookFile = path.join(settings.highlightsFolder, `${bookTitle}.md`);
+export const checkBookExistence = async (
+  item: ICombinedBooksAndHighlights,
+  vault: Vault,
+  settings: AppleBooksHighlightsImportPluginSettings,
+): Promise<boolean> => {
+  const renderedFilename = await renderHighlightsTemplate(item, settings.filenameTemplate);
+  const pathToBookFile = path.join(settings.highlightsFolder, `${renderedFilename}.md`);
   const doesBookFileExist = vault.getFileByPath(pathToBookFile);
 
   return doesBookFileExist ? true : false;

--- a/test/backupHighlights.spec.ts
+++ b/test/backupHighlights.spec.ts
@@ -76,15 +76,25 @@ describe('Backup all highlights', () => {
 
 describe('Backup single book highlights', () => {
   test('Should backup a single book highlights', async () => {
-    const bookTitle = 'Hello-world';
-    const vaultFile = { path: `${settings.highlightsFolder}/${bookTitle}.md` };
+    const filename = 'Hello-world';
+    const vaultFile = { path: `${settings.highlightsFolder}/${filename}.md` };
     mockVault.getFileByPath = vi.fn().mockReturnValue(vaultFile);
 
-    const backupBookTitle = `${bookTitle}-bk-1704060001.md`;
+    const backupBookTitle = `${filename}-bk-1704060001.md`;
 
     const backupHighlights = new BackupHighlights(mockVault as any, settings);
-    await backupHighlights.backupSingleBookHighlights(bookTitle);
+    await backupHighlights.backupSingleBookHighlights(filename);
 
     expect(mockVault.adapter.copy).toHaveBeenCalledWith(vaultFile.path, `${settings.highlightsFolder}/${backupBookTitle}`);
+  });
+
+  test('Should skip backup if the book file does not exist (when file template was changed between imports of the same book)', async () => {
+    const filename = 'Hello-world';
+    mockVault.getFileByPath = vi.fn().mockReturnValue(null);
+
+    const backupHighlights = new BackupHighlights(mockVault as any, settings);
+    await backupHighlights.backupSingleBookHighlights(filename);
+
+    expect(mockVault.adapter.copy).not.toHaveBeenCalled();
   });
 });

--- a/test/checkBookExistence.spec.ts
+++ b/test/checkBookExistence.spec.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { AppleBooksHighlightsImportPluginSettings } from '../src/settings';
+import type { ICombinedBooksAndHighlights } from '../src/types';
 import { checkBookExistence } from '../src/utils/checkBookExistence';
+import { aggregatedUnsortedHighlights } from './mocks/aggregatedDetailsData';
 
 describe('checkBookExistence', () => {
   const mockVault = {
@@ -13,20 +15,22 @@ describe('checkBookExistence', () => {
     vi.resetAllMocks();
   });
 
-  test('Should return false if the book file does not exist', () => {
-    const bookTitle = 'Hello World';
+  test('Should return false if the book file does not exist', async () => {
+    const item = aggregatedUnsortedHighlights[0] as ICombinedBooksAndHighlights;
+
     mockVault.getFileByPath.mockReturnValue(null);
 
-    const checkResult = checkBookExistence(bookTitle, mockVault as any, settings);
+    const checkResult = await checkBookExistence(item, mockVault as any, settings);
 
     expect(checkResult).toBe(false);
   });
 
-  test('Should return true if the book file exists', () => {
-    const bookTitle = 'Hello World';
-    mockVault.getFileByPath.mockReturnValue({ path: `${settings.highlightsFolder}/${bookTitle}.md` });
+  test('Should return true if the book file exists', async () => {
+    const item = aggregatedUnsortedHighlights[0] as ICombinedBooksAndHighlights;
 
-    const checkResult = checkBookExistence(bookTitle, mockVault as any, settings);
+    mockVault.getFileByPath.mockReturnValue({ path: `${settings.highlightsFolder}/Hello World.md` });
+
+    const checkResult = await checkBookExistence(item, mockVault as any, settings);
 
     expect(checkResult).toBe(true);
   });


### PR DESCRIPTION
# Description

This PR fixes two errors that appear when importing a book with a custom filename template. The root cause of the error was that several functions were checking a book file using its raw title instead of the rendered filename template. When the filename template was changing, these functions incorrectly assumed the file existed (based on the old path), but then tried to modify it (or create a backup) at the new path, which didn't exist.

Fixes #67
Fixes #68 

# Checklist

- [x] I accept the [Code of Conduct](https://github.com/bandantonio/obsidian-apple-books-highlights-plugin/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I have performed a self-review of my code for consistency and potential leftover debug logs, commented out code, etc.
- [x] I have added tests that prove that my feature works or that the fix is effective
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if necessary)
- [x] I confirm that this PR DOESN'T change the plugin's version either in the `manifest.json` or `package.json` files
- [x] I have checked that my commit messages are descriptive and follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] I have enabled the checkbox to allow maintainer edits so the branch can be updated for a merge.
