### PR TITLE
chore: update Node.js version to 24 and upgrade action versions in workflows

### DIFF
--- a/.github/actions/node-cache/action.yml
+++ b/.github/actions/node-cache/action.yml
@@ -3,9 +3,9 @@ description: 'Setup Node.js packages and restore cache'
 
 inputs:
   node-version:
-    description: 'Node version to use, default to 20'
+    description: 'Node version to use, default to 24'
     required: true
-    default: '20'
+    default: '24'
 outputs:
   cache-hit:
     description: 'Forward actions/cache cache-hit output'
@@ -15,13 +15,13 @@ runs:
   using: 'composite'
   steps:
     - name: ⚙️ Setup node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
 
     - name: 📦 Cache node modules
       id: node-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: node_modules
         key: node-modules-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,14 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Setup Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,12 @@ jobs:
     name: ⚙️ Setup Node.js
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/node-cache
         id: cache-node-modules
         with:
-          node-version: '20'
-      - run: npm i
+          node-version: '24'
+      - run: npm ci
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
 
   run-lint:
@@ -23,11 +23,11 @@ jobs:
     needs: node-setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/node-cache
         id: cache-node-modules
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: ✅ Run code style linter
         id: linter
@@ -38,11 +38,11 @@ jobs:
     needs: node-setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/node-cache
         id: cache-node-modules
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: 🧪 Run tests
         id: tests
@@ -60,11 +60,11 @@ jobs:
     needs: [run-lint, run-tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/node-cache
         id: cache-node-modules
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: 📗 Build plugin
         id: build_plugin


### PR DESCRIPTION
# Description

This PR removes deprecation notices via updating action versions.

<img width="1407" height="398" alt="Screenshot 2026-04-02 at 10 41 15 PM" src="https://github.com/user-attachments/assets/a184f99a-a82e-4532-8419-a7b8d6737661" />

<img width="1408" height="238" alt="Screenshot 2026-04-02 at 10 41 50 PM" src="https://github.com/user-attachments/assets/02b3633b-2da3-4e9a-81ad-754d400b6c51" />

# Checklist

- [x] I accept the [Code of Conduct](https://github.com/bandantonio/obsidian-apple-books-highlights-plugin/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I have performed a self-review of my code for consistency and potential leftover debug logs, commented out code, etc.
- [x] I have added tests that prove that my feature works or that the fix is effective
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly (if necessary)
- [x] I confirm that this PR DOESN'T change the plugin's version either in the `manifest.json` or `package.json` files
- [x] I have checked that my commit messages are descriptive and follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [x] I have enabled the checkbox to allow maintainer edits so the branch can be updated for a merge.
