### PR TITLE
fix: add proper escaping to filename template default value

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-  "id": "apple-books-import-highlights",
-  "name": "Apple Books - Import Highlights",
-  "version": "1.8.0",
-  "minAppVersion": "0.15.0",
-  "description": "Import your Apple Books highlights and notes to Obsidian.",
-  "author": "bandantonio",
-  "authorUrl": "https://github.com/bandantonio",
-  "isDesktopOnly": true
+	"id": "apple-books-import-highlights",
+	"name": "Apple Books - Import Highlights",
+	"version": "1.8.1",
+	"minAppVersion": "0.15.0",
+	"description": "Import your Apple Books highlights and notes to Obsidian.",
+	"author": "bandantonio",
+	"authorUrl": "https://github.com/bandantonio",
+	"isDesktopOnly": true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-apple-books-highlights-plugin",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"description": "Import highlights and notes from your Apple Books to Obsidian",
 	"main": "main.js",
 	"scripts": {
@@ -18,7 +18,7 @@
 		"lint:staged": "oxfmt --config ./.oxfmtrc.json --no-error-on-unmatched-pattern",
 		"postinstall": "npm run setup:git-hooks",
 		"setup:git-hooks": "git config core.hooksPath .git-hooks",
-    "test": "vitest --run",
+		"test": "vitest --run",
 		"version": "node versioning.mjs"
 	},
 	"author": "bandantonio",
@@ -52,13 +52,13 @@
 		"@vitest/coverage-v8": "^4.1.5",
 		"better-sqlite3": "^12.2.0",
 		"builtin-modules": "3.3.0",
-    "esbuild": "0.27.7",
+		"esbuild": "0.27.7",
 		"obsidian": "latest",
-    "oxfmt": "^0.47.0",
-    "oxlint": "^1.62.0",
+		"oxfmt": "^0.47.0",
+		"oxlint": "^1.62.0",
 		"tslib": "2.8.1",
 		"typescript": "5.9.2",
-    "vitepress": "^2.0.0-alpha.17",
+		"vitepress": "^2.0.0-alpha.17",
 		"vitest": "^4.1.5"
 	}
 }

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -36,7 +36,7 @@ export const defaultPluginSettings: IBookHighlightsPluginSettings = {
   importOnStart: false,
   highlightsSortingCriterion: 'creationDateOldToNew',
   template: defaultTemplate,
-  filenameTemplate: allowedFilenameTemplateVariables[0],
+  filenameTemplate: `{{{${allowedFilenameTemplateVariables[0]}}}}`,
   keepMeSectionOpeningDelimiter: '%% keep-me %%',
   keepMeSectionClosingDelimiter: '%% /keep-me %%',
   keepMeSectionData: {},
@@ -189,7 +189,7 @@ export class IBookHighlightsSettingTab extends PluginSettingTab {
           }
           el.createEl('br');
           // The first variable is the default one
-          el.appendText(`Default: {{{${defaultPluginSettings.filenameTemplate}}}}`);
+          el.appendText(`Default: ${defaultPluginSettings.filenameTemplate}`);
         }),
       )
       .setClass('ibooks-highlights-file-naming-template');
@@ -199,7 +199,7 @@ export class IBookHighlightsSettingTab extends PluginSettingTab {
         .setPlaceholder('Naming template for highlight files')
         .setValue(this.plugin.settings.filenameTemplate)
         .onChange(async (value) => {
-          const valueToSet = value === '' ? `{{{${defaultPluginSettings.filenameTemplate}}}}` : value;
+          const valueToSet = value === '' ? defaultPluginSettings.filenameTemplate : value;
           this.plugin.settings.filenameTemplate = valueToSet;
 
           await this.plugin.saveSettings();

--- a/test/unit/settings/settings.spec.ts
+++ b/test/unit/settings/settings.spec.ts
@@ -24,7 +24,7 @@ describe('Default settings', () => {
     expect(defaultPluginSettings.importOnStart).toBe(false);
     expect(defaultPluginSettings.highlightsSortingCriterion).toBe('creationDateOldToNew');
     expect(defaultPluginSettings.template).toBe(defaultTemplate);
-    expect(defaultPluginSettings.filenameTemplate).toBe('bookTitle');
+    expect(defaultPluginSettings.filenameTemplate).toBe('{{{bookTitle}}}');
   });
 
   test('Should check that default template contains the expected variables with proper escaping', () => {


### PR DESCRIPTION
# Description

Fixes #78

# Checklist

- [x] I confirm that this PR DOESN'T change the plugin's version either in the `manifest.json` or `package.json` files
- [x] I have enabled the checkbox to allow maintainer edits
