### PR TITLE
feat: add Apple Books knowledge cards and reading dashboard

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -19,6 +19,8 @@ const buildOptions = {
   external: [
     'obsidian',
     'electron',
+    'child_process',
+    'os',
     '@codemirror/autocomplete',
     '@codemirror/collab',
     '@codemirror/commands',

--- a/main.ts
+++ b/main.ts
@@ -1,11 +1,19 @@
-import { Plugin } from 'obsidian';
+import { Notice, Platform, Plugin } from 'obsidian';
 import type { IBookHighlightsPluginSettings } from './src/types';
-import { IBookHighlightsPluginSearchModal } from './src/modals/searchSuggestions';
+import { getHighlightCards } from './src/modules/highlightRepository';
 import { VaultManagement } from './src/modules/vaultManagement';
 import { defaultPluginSettings, IBookHighlightsSettingTab } from './src/settings';
-import { backupAndImport } from './src/utils/backupAndImportFlow';
 import { saveKeepMeSectionData } from './src/utils/manageKeepMeSection';
 import { showFailedImportNotice, showErrorInConsole } from './src/utils/notificationCenter';
+import { renderCardsBoard } from './src/views/cardRenderer';
+import { CARDS_VIEW_TYPE, CardsView, openCardsView } from './src/views/cardsView';
+import { DASHBOARD_VIEW_TYPE, DashboardView, openDashboardView, renderDashboard } from './src/views/dashboardView';
+
+const showNotice = (message: string, timeout?: number): void => {
+  const notice = new Notice(message, timeout);
+  void notice;
+};
+
 export default class IBookHighlightsPlugin extends Plugin {
   vault: VaultManagement;
   settings: IBookHighlightsPluginSettings;
@@ -15,12 +23,22 @@ export default class IBookHighlightsPlugin extends Plugin {
     this.vault = new VaultManagement(this.app, this.settings);
 
     this.addSettingTab(new IBookHighlightsSettingTab(this.app, this));
-    addRibbonAction(this);
-    addImportAllBooksCommand(this);
-    addImportOneBookCommand(this);
+    if (!Platform.isMobile) {
+      addRibbonAction(this);
+      addImportAllBooksCommand(this);
+      addImportOneBookCommand(this);
+    }
+    addDashboardRibbonAction(this);
+    addOpenDashboardCommand(this);
+    addOpenCardsWallCommand(this);
+    registerCardsView(this);
+    registerDashboardView(this);
+    registerCardsCodeBlock(this);
+    registerDashboardCodeBlock(this);
 
-    if (this.settings.importOnStart) {
+    if (this.settings.importOnStart && !Platform.isMobile) {
       this.app.workspace.onLayoutReady(async () => {
+        const { backupAndImport } = await import('./src/utils/backupAndImportFlow');
         await backupAndImport(this, this.settings, 'modify');
       });
     }
@@ -51,16 +69,34 @@ export default class IBookHighlightsPlugin extends Plugin {
 }
 
 function addRibbonAction(plugin: IBookHighlightsPlugin) {
-  plugin.addRibbonIcon('book-open', `${plugin.manifest.name}: Import all`, async () => {
+  plugin.addRibbonIcon('book-open', `${plugin.manifest.name}: 导入全部`, async () => {
+    if (Platform.isMobile) {
+      showNotice('iOS/iPadOS 端暂不支持从 Apple Books 数据库导入，请在 Mac 端导入后通过 iCloud 同步查看。');
+      return;
+    }
+
+    const { backupAndImport } = await import('./src/utils/backupAndImportFlow');
     await backupAndImport(plugin, plugin.settings);
+  });
+}
+
+function addDashboardRibbonAction(plugin: IBookHighlightsPlugin) {
+  plugin.addRibbonIcon('layout-dashboard', `${plugin.manifest.name}: 打开阅读仪表盘`, async () => {
+    await openDashboardView(plugin);
   });
 }
 
 function addImportAllBooksCommand(plugin: IBookHighlightsPlugin) {
   plugin.addCommand({
     id: 'import-all-highlights',
-    name: 'Import all',
+    name: '导入全部 Apple Books 摘录',
     callback: async () => {
+      if (Platform.isMobile) {
+        showNotice('iOS/iPadOS 端暂不支持导入 Apple Books 数据库，请在 Mac 端导入后同步查看。');
+        return;
+      }
+
+      const { backupAndImport } = await import('./src/utils/backupAndImportFlow');
       await backupAndImport(plugin, plugin.settings);
     },
   });
@@ -69,14 +105,76 @@ function addImportAllBooksCommand(plugin: IBookHighlightsPlugin) {
 function addImportOneBookCommand(plugin: IBookHighlightsPlugin) {
   plugin.addCommand({
     id: 'import-single-highlights',
-    name: 'From a specific book...',
-    callback: () => {
+    name: '导入指定书籍...',
+    callback: async () => {
+      if (Platform.isMobile) {
+        showNotice('iOS/iPadOS 端暂不支持导入指定书籍，请在 Mac 端导入后同步查看。');
+        return;
+      }
+
       try {
+        const { IBookHighlightsPluginSearchModal } = await import('./src/modals/searchSuggestions');
         new IBookHighlightsPluginSearchModal(plugin.app, plugin).open();
       } catch (error) {
         showFailedImportNotice(plugin.manifest.name);
         showErrorInConsole(plugin.manifest.name, error);
       }
     },
+  });
+}
+
+function addOpenCardsWallCommand(plugin: IBookHighlightsPlugin) {
+  plugin.addCommand({
+    id: 'open-cards-wall',
+    name: '打开 Apple Books 摘录',
+    callback: async () => {
+      await openCardsView(plugin);
+    },
+  });
+}
+
+function addOpenDashboardCommand(plugin: IBookHighlightsPlugin) {
+  plugin.addCommand({
+    id: 'open-reading-dashboard',
+    name: '打开 Apple Books 阅读仪表盘',
+    callback: async () => {
+      await openDashboardView(plugin);
+    },
+  });
+}
+
+function registerCardsView(plugin: IBookHighlightsPlugin) {
+  plugin.registerView(CARDS_VIEW_TYPE, (leaf) => new CardsView(leaf, plugin));
+}
+
+function registerDashboardView(plugin: IBookHighlightsPlugin) {
+  plugin.registerView(DASHBOARD_VIEW_TYPE, (leaf) => new DashboardView(leaf, plugin));
+}
+
+function registerCardsCodeBlock(plugin: IBookHighlightsPlugin) {
+  plugin.registerMarkdownCodeBlockProcessor('apple-books-board', async (source, el) => {
+    const bookId = source.match(/book_id:\s*(.+)/)?.[1]?.trim();
+    const render = async () => {
+      try {
+        const cards = await getHighlightCards(plugin.app, plugin.settings);
+
+        renderCardsBoard(plugin.app, el, cards, { bookId }, { onRefresh: render });
+      } catch (error) {
+        el.empty();
+        el.createDiv({
+          cls: 'abkc-empty',
+          text: `Apple Books 摘录卡片加载失败：${error instanceof Error ? error.message : String(error)}`,
+        });
+        showErrorInConsole(plugin.manifest.name, error);
+      }
+    };
+
+    await render();
+  });
+}
+
+function registerDashboardCodeBlock(plugin: IBookHighlightsPlugin) {
+  plugin.registerMarkdownCodeBlockProcessor('apple-books-dashboard', async (_source, el) => {
+    await renderDashboard(plugin, el);
   });
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-  "id": "apple-books-import-highlights",
-  "name": "Apple Books - Import Highlights",
+  "id": "apple-books-knowledge-cards",
+  "name": "Apple Books Knowledge Cards",
   "version": "1.8.1",
   "minAppVersion": "1.5.7",
-  "description": "Import your Apple Books highlights and notes to Obsidian.",
-  "author": "bandantonio",
-  "authorUrl": "https://github.com/bandantonio",
-  "isDesktopOnly": true
+  "description": "Import Apple Books highlights as structured notes and knowledge cards.",
+  "author": "jinjideweima, based on bandantonio",
+  "authorUrl": "https://github.com/jinjideweima",
+  "isDesktopOnly": false
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "obsidian-apple-books-highlights-plugin",
+	"name": "apple-books-knowledge-cards",
 	"version": "1.8.1",
-	"description": "Import highlights and notes from your Apple Books to Obsidian",
+	"description": "Import Apple Books highlights as structured notes and knowledge cards",
 	"main": "main.js",
 	"scripts": {
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production && npm run copy-assets",
@@ -21,10 +21,10 @@
 		"test": "vitest --run",
 		"version": "node versioning.mjs"
 	},
-	"author": "bandantonio",
+	"author": "jinjideweima, based on bandantonio",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/bandantonio/obsidian-apple-books-highlights-plugin.git"
+		"url": "git+https://github.com/jinjideweima/obsidian-apple-books-highlights-plugin.git"
 	},
 	"license": "MIT",
 	"keywords": [

--- a/src/importHighlights.ts
+++ b/src/importHighlights.ts
@@ -1,5 +1,6 @@
 import type { IBookHighlightsPluginSettings } from './types';
 import { aggregateBooksWithAnnotations } from './modules/annotationsProcessing';
+import { importHighlightCards } from './modules/highlightCards';
 import { compileTemplate } from './modules/templateProcessing';
 import { VaultManagement } from './modules/vaultManagement';
 import { getKeepMeSectionDataFromSettings, embedKeepMeSectionDataIntoBookFile } from './utils/manageKeepMeSection';
@@ -19,44 +20,37 @@ export const importHighlights = async (
   const precompiledTemplate = compileTemplate(settings.template);
   const precompiledFilenameTemplate = compileTemplate(settings.filenameTemplate);
 
-  const fileOperations = [];
-
   for (const bookWithAnnotations of aggregatedBooksAndAnnotations) {
-    const preCompiledContent = precompiledTemplate(bookWithAnnotations);
     const compiledFilename = precompiledFilenameTemplate(bookWithAnnotations);
 
-    const keepMeSectionData = getKeepMeSectionDataFromSettings(compiledFilename, settings);
+    try {
+      const preCompiledContent = precompiledTemplate(bookWithAnnotations);
+      const keepMeSectionData = getKeepMeSectionDataFromSettings(compiledFilename, settings);
 
-    let compiledContent = preCompiledContent;
+      let compiledContent = preCompiledContent;
 
-    if (keepMeSectionData) {
-      compiledContent = embedKeepMeSectionDataIntoBookFile(keepMeSectionData, preCompiledContent, settings);
-    }
-
-    if (importMode === 'create') {
-      fileOperations.push(vault.createBookFile(compiledFilename, compiledContent));
-    } else if (importMode === 'modify') {
-      const filePath = vault.getFilePath(compiledFilename);
-
-      if (filePath) {
-        fileOperations.push(vault.modifyBookFile(filePath, compiledContent));
-      } else {
-        console.warn(
-          `Apple Books - Import Highlights: Can't modify "${compiledFilename}". Book does not exist. Creating a new book instead.`,
-        );
-        fileOperations.push(vault.createBookFile(compiledFilename, compiledContent));
+      if (keepMeSectionData) {
+        compiledContent = embedKeepMeSectionDataIntoBookFile(keepMeSectionData, preCompiledContent, settings);
       }
+
+      if (importMode === 'create') {
+        await vault.createBookFile(compiledFilename, compiledContent);
+      } else if (importMode === 'modify') {
+        const filePath = vault.getFilePath(compiledFilename);
+
+        if (filePath) {
+          await vault.modifyBookFile(filePath, compiledContent);
+        } else {
+          console.warn(`Apple Books Knowledge Cards: 无法修改“${compiledFilename}”，因为书籍主笔记不存在。将改为新建。`);
+          await vault.createBookFile(compiledFilename, compiledContent);
+        }
+      }
+
+      await importHighlightCards(vault, bookWithAnnotations, compiledFilename);
+    } catch (error) {
+      throw new Error(`导入《${bookWithAnnotations.bookTitle}》失败：${error instanceof Error ? error.message : String(error)}`, {
+        cause: error,
+      });
     }
-  }
-
-  const results = await Promise.allSettled(fileOperations);
-
-  const rejected = results.filter((result): result is PromiseRejectedResult => result.status === 'rejected');
-
-  if (rejected.length > 0) {
-    throw new AggregateError(
-      rejected.map((result) => result.reason),
-      `Apple Books - Import Highlights: ${rejected.length} file operation(s) failed during import.`,
-    );
   }
 };

--- a/src/modals/overwriteConsent.ts
+++ b/src/modals/overwriteConsent.ts
@@ -1,6 +1,8 @@
 import { type App, Modal, Setting, TFile } from 'obsidian';
 import type IBookHighlightsPlugin from '../../main';
+import type { IBookWithAnnotations } from '../types';
 import { importHighlights } from '../importHighlights';
+import { importHighlightCards } from '../modules/highlightCards';
 import { showFailedImportNotice, showSuccessfulImportNotice, showErrorInConsole } from '../utils/notificationCenter';
 
 // This class is used to display a modal that asks for the user's consent
@@ -10,9 +12,13 @@ import { showFailedImportNotice, showSuccessfulImportNotice, showErrorInConsole 
 // to overwrite all the books
 export class OverwriteBookModal extends Modal {
   plugin: IBookHighlightsPlugin;
-  fileDetails?: { file: TFile; compiledContent: string };
+  fileDetails?: { file: TFile; compiledContent: string; book?: IBookWithAnnotations; compiledFilename?: string };
 
-  constructor(app: App, plugin: IBookHighlightsPlugin, fileDetails?: { file: TFile; compiledContent: string }) {
+  constructor(
+    app: App,
+    plugin: IBookHighlightsPlugin,
+    fileDetails?: { file: TFile; compiledContent: string; book?: IBookWithAnnotations; compiledFilename?: string },
+  ) {
     super(app);
     this.plugin = plugin;
     this.fileDetails = fileDetails;
@@ -23,24 +29,27 @@ export class OverwriteBookModal extends Modal {
     const bookToOverwrite = this.fileDetails;
 
     if (bookToOverwrite) {
-      contentEl.createEl('p', { text: 'The selected book already exists in your highlights folder:' });
+      contentEl.createEl('p', { text: '选中的书籍主笔记已经存在：' });
       contentEl.createEl('p', { text: `${bookToOverwrite.file.name}`, cls: 'modal-rewrite-book-title' });
-      contentEl.createEl('p', { text: 'Would you like to proceed with the overwrite?' });
+      contentEl.createEl('p', { text: '是否继续覆盖？' });
     } else {
-      contentEl.createSpan({ text: 'Bulk import will overwrite' });
-      contentEl.createSpan({ text: ' ALL THE BOOKS ', cls: 'modal-rewrite-all-books' });
-      contentEl.createSpan({ text: 'in your highlights folder' });
-      contentEl.createEl('p', { text: 'Would you like to proceed with the overwrite?' });
+      contentEl.createSpan({ text: '批量导入会覆盖导入目录中的' });
+      contentEl.createSpan({ text: ' 所有书籍主笔记 ', cls: 'modal-rewrite-all-books' });
+      contentEl.createSpan({ text: '。独立摘录卡片会按稳定 ID 更新。' });
+      contentEl.createEl('p', { text: '是否继续？' });
     }
 
     new Setting(contentEl)
       .addButton((YesButton) => {
-        YesButton.setButtonText('Yes, overwrite')
+        YesButton.setButtonText('确认覆盖')
           .setCta()
           .onClick(async () => {
             try {
               if (bookToOverwrite) {
                 await this.plugin.vault.modifyBookFile(bookToOverwrite.file, bookToOverwrite.compiledContent);
+                if (bookToOverwrite.book && bookToOverwrite.compiledFilename) {
+                  await importHighlightCards(this.plugin.vault, bookToOverwrite.book, bookToOverwrite.compiledFilename);
+                }
               } else {
                 await importHighlights(this.plugin.vault, this.plugin.settings, 'modify');
               }
@@ -54,7 +63,7 @@ export class OverwriteBookModal extends Modal {
       })
 
       .addButton((NoButton) => {
-        NoButton.setButtonText('No').onClick(() => {
+        NoButton.setButtonText('取消').onClick(() => {
           this.close();
         });
       });

--- a/src/modals/searchSuggestions.ts
+++ b/src/modals/searchSuggestions.ts
@@ -2,6 +2,7 @@ import { type App, SuggestModal } from 'obsidian';
 import type IBookHighlightsPlugin from '../../main';
 import type { IBookWithAnnotations } from '../types';
 import { aggregateBooksWithAnnotations } from '../modules/annotationsProcessing';
+import { importHighlightCards } from '../modules/highlightCards';
 import { compileTemplate } from '../modules/templateProcessing';
 import { getKeepMeSectionDataFromSettings, embedKeepMeSectionDataIntoBookFile } from '../utils/manageKeepMeSection';
 import { showFailedImportNotice, showErrorInConsole } from '../utils/notificationCenter';
@@ -76,17 +77,21 @@ export class IBookHighlightsPluginSearchModal extends IBookHighlightsPluginSugge
       // or when the book was renamed to the title that doesn't match the defined template.
       if (!doesBookFileExist) {
         await this.plugin.vault.createBookFile(compiledFilename, compiledContent);
+        await importHighlightCards(this.plugin.vault, book, compiledFilename);
       }
 
       if (isBackupEnabled && doesBookFileExist) {
         await this.plugin.vault.backupBookFile(file!);
         await this.plugin.vault.createBookFile(compiledFilename, compiledContent);
+        await importHighlightCards(this.plugin.vault, book, compiledFilename);
       }
 
       if (!isBackupEnabled && doesBookFileExist) {
         const fileDetails = {
           file: file!,
           compiledContent,
+          book,
+          compiledFilename,
         };
 
         new OverwriteBookModal(this.app, this.plugin, fileDetails).open();

--- a/src/modules/annotationsProcessing.ts
+++ b/src/modules/annotationsProcessing.ts
@@ -1,5 +1,6 @@
 import type { IBook, IAnnotation, IBookWithAnnotations, IHighlightsSortingCriterion } from '../types';
 import { getBooks, getAnnotations } from './dataFetching';
+import { inferMissingChapters } from './epubChapters';
 
 export const aggregateBooksWithAnnotations = async (sortingCriterion: IHighlightsSortingCriterion): Promise<IBookWithAnnotations[]> => {
   const [books, annotations] = await Promise.all([getBooks(), getAnnotations(sortingCriterion)]);
@@ -9,6 +10,7 @@ export const aggregateBooksWithAnnotations = async (sortingCriterion: IHighlight
 
   const booksWithAnnotations: IBookWithAnnotations[] = [];
   enrichBooksWithAnnotations(books, annotationsMap, booksWithAnnotations);
+  await inferMissingChapters(booksWithAnnotations);
 
   return booksWithAnnotations;
 };
@@ -19,7 +21,7 @@ export function enrichBooksWithAnnotations(
   booksWithAnnotations: IBookWithAnnotations[],
 ) {
   for (const book of books) {
-    const { bookId, bookTitle, bookAuthor, bookGenre, bookLanguage, bookLastOpenedDate, bookFinishedDate, bookCoverUrl } = book;
+    const { bookId, bookTitle, bookAuthor, bookGenre, bookLanguage, bookLastOpenedDate, bookFinishedDate, bookCoverUrl, bookPath } = book;
 
     const bookRelatedAnnotations = annotationsMap.get(bookId) || [];
     if (bookRelatedAnnotations.length > 0) {
@@ -33,6 +35,7 @@ export function enrichBooksWithAnnotations(
         bookLastOpenedDate,
         bookFinishedDate,
         bookCoverUrl,
+        bookPath,
         annotations: bookRelatedAnnotations.map((annotation) => {
           const {
             assetId,

--- a/src/modules/dataFetching.ts
+++ b/src/modules/dataFetching.ts
@@ -1,25 +1,46 @@
-import os from 'os';
-import path from 'path';
 import type { IBook, IAnnotation, IHighlightsSortingCriterion } from '../types';
 import { executeDbQuery } from '../utils/databaseQuery';
+import { requireNodeModule } from '../utils/nodeModules';
 import { sortByLocation } from './annotationsProcessing';
 
+const getEnvValue = (key: string): string | undefined => {
+  return typeof process !== 'undefined' ? process.env[key] : undefined;
+};
+
 export const getBooksDbPath = (): string => {
+  const os = requireNodeModule<typeof import('os')>('os');
+  const path = requireNodeModule<typeof import('path')>('path');
+
   return (
-    process.env.BOOKS_DB_PATH ||
+    getEnvValue('BOOKS_DB_PATH') ||
     path.join(os.homedir(), 'Library/Containers/com.apple.iBooksX/Data/Documents/BKLibrary/BKLibrary-1-091020131601.sqlite')
   );
 };
 
 export const getAnnotationsDbPath = (): string => {
+  const os = requireNodeModule<typeof import('os')>('os');
+  const path = requireNodeModule<typeof import('path')>('path');
+
   return (
-    process.env.ANNOTATIONS_DB_PATH ||
+    getEnvValue('ANNOTATIONS_DB_PATH') ||
     path.join(os.homedir(), 'Library/Containers/com.apple.iBooksX/Data/Documents/AEAnnotation/AEAnnotation_v10312011_1727_local.sqlite')
   );
 };
 
+const getOptionalBookPathSelect = async (dbPath: string): Promise<string> => {
+  try {
+    const columns = await executeDbQuery<Array<{ name: string }>>(dbPath, 'PRAGMA table_info(ZBKLIBRARYASSET)');
+    const hasPathColumn = columns.some((column) => column.name === 'ZPATH');
+
+    return hasPathColumn ? 'ZPATH as bookPath' : "'' as bookPath";
+  } catch {
+    return "'' as bookPath";
+  }
+};
+
 export const getBooks = async (): Promise<IBook[]> => {
   const BOOKS_DB_PATH = getBooksDbPath();
+  const bookPathSelect = await getOptionalBookPathSelect(BOOKS_DB_PATH);
 
   const dbQuery = `SELECT
   ZASSETID as bookId,
@@ -29,7 +50,8 @@ export const getBooks = async (): Promise<IBook[]> => {
   ZLANGUAGE as bookLanguage,
   ZLASTOPENDATE as bookLastOpenedDate,
   ZDATEFINISHED as bookFinishedDate,
-  ZCOVERURL as bookCoverUrl
+  ZCOVERURL as bookCoverUrl,
+  ${bookPathSelect}
   FROM ZBKLIBRARYASSET
   WHERE ZPURCHASEDATE IS NOT NULL`;
 

--- a/src/modules/epubChapters.ts
+++ b/src/modules/epubChapters.ts
@@ -1,0 +1,370 @@
+import type { IBookWithAnnotations } from '../types';
+import { requireNodeModule } from '../utils/nodeModules';
+
+interface TocEntry {
+  href: string;
+  label: string;
+}
+
+interface EpubFileReader {
+  readText: (relativePath: string) => Promise<string>;
+  listFiles: () => Promise<string[]>;
+}
+
+const textDecoder = new TextDecoder('utf-8');
+
+const normalizePath = (value: string): string => decodeURIComponent(value.split('#')[0]).replace(/^\.?\//, '');
+
+const dirname = (value: string): string => {
+  const lastSlashIndex = value.lastIndexOf('/');
+
+  if (lastSlashIndex === -1) {
+    return '';
+  }
+
+  return value.slice(0, lastSlashIndex);
+};
+
+const joinPath = (...parts: string[]): string => {
+  return parts
+    .filter(Boolean)
+    .join('/')
+    .replace(/\/+/g, '/')
+    .replace(/^\.?\//, '');
+};
+
+const stripXml = (value: string): string => {
+  return value
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+const getAttr = (tag: string, attrName: string): string => {
+  const attrMatch = tag.match(new RegExp(`${attrName}\\s*=\\s*["']([^"']+)["']`, 'i'));
+
+  return attrMatch?.[1] || '';
+};
+
+const createDirectoryReader = async (rootPath: string): Promise<EpubFileReader> => {
+  const fs = requireNodeModule<typeof import('fs/promises')>('fs/promises');
+  const path = requireNodeModule<typeof import('path')>('path');
+
+  const listFiles = async (directory: string, prefix = ''): Promise<string[]> => {
+    const entries = await fs.readdir(directory, { withFileTypes: true });
+    const files = await Promise.all(
+      entries.map(async (entry) => {
+        const relativePath = joinPath(prefix, entry.name);
+        const absolutePath = path.join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+          return listFiles(absolutePath, relativePath);
+        }
+
+        return [relativePath];
+      }),
+    );
+
+    return files.flat();
+  };
+
+  return {
+    readText: async (relativePath: string) => fs.readFile(path.join(rootPath, relativePath), 'utf8'),
+    listFiles: async () => listFiles(rootPath),
+  };
+};
+
+const createZipReader = async (rootPath: string): Promise<EpubFileReader> => {
+  const fs = requireNodeModule<typeof import('fs/promises')>('fs/promises');
+  const { inflateRawSync } = requireNodeModule<typeof import('zlib')>('zlib');
+  const buffer = await fs.readFile(rootPath);
+  const entries = new Map<string, Buffer>();
+  let offset = 0;
+
+  while (offset < buffer.length && buffer.readUInt32LE(offset) === 0x04034b50) {
+    const compressionMethod = buffer.readUInt16LE(offset + 8);
+    const compressedSize = buffer.readUInt32LE(offset + 18);
+    const uncompressedSize = buffer.readUInt32LE(offset + 22);
+    const fileNameLength = buffer.readUInt16LE(offset + 26);
+    const extraFieldLength = buffer.readUInt16LE(offset + 28);
+    const fileName = buffer.subarray(offset + 30, offset + 30 + fileNameLength).toString('utf8');
+    const dataStart = offset + 30 + fileNameLength + extraFieldLength;
+    const dataEnd = dataStart + compressedSize;
+    const compressedData = buffer.subarray(dataStart, dataEnd);
+
+    if (!fileName.endsWith('/')) {
+      if (compressionMethod === 0) {
+        entries.set(fileName, compressedData);
+      } else if (compressionMethod === 8) {
+        const data = inflateRawSync(compressedData, { finishFlush: 2 });
+        entries.set(fileName, uncompressedSize ? data.subarray(0, uncompressedSize) : data);
+      }
+    }
+
+    offset = dataEnd;
+  }
+
+  return {
+    readText: async (relativePath: string) => {
+      const content = entries.get(relativePath);
+
+      if (!content) {
+        throw new Error(`找不到 EPUB 文件：${relativePath}`);
+      }
+
+      return textDecoder.decode(content);
+    },
+    listFiles: async () => Array.from(entries.keys()),
+  };
+};
+
+const createReader = async (bookPath: string): Promise<EpubFileReader | null> => {
+  if (!bookPath) {
+    return null;
+  }
+
+  try {
+    const fs = requireNodeModule<typeof import('fs/promises')>('fs/promises');
+    const stat = await fs.stat(bookPath);
+
+    return stat.isDirectory() ? createDirectoryReader(bookPath) : createZipReader(bookPath);
+  } catch (error) {
+    console.warn(`Apple Books Knowledge Cards: 无法读取 EPUB：${bookPath}`, error);
+    return null;
+  }
+};
+
+const findOpfPath = async (reader: EpubFileReader): Promise<string> => {
+  try {
+    const containerXml = await reader.readText('META-INF/container.xml');
+    const rootfileTag = containerXml.match(/<rootfile\b[^>]*>/i)?.[0] || '';
+    const opfPath = getAttr(rootfileTag, 'full-path');
+
+    if (opfPath) {
+      return normalizePath(opfPath);
+    }
+  } catch {
+    // Fall through to file scan.
+  }
+
+  const files = await reader.listFiles();
+
+  return files.find((file) => file.toLowerCase().endsWith('.opf')) || '';
+};
+
+const getManifestItems = (opf: string): Map<string, string> => {
+  const items = new Map<string, string>();
+  const itemRegex = /<item\b[^>]*>/gi;
+  let itemMatch: RegExpExecArray | null;
+
+  while ((itemMatch = itemRegex.exec(opf))) {
+    const tag = itemMatch[0];
+    const id = getAttr(tag, 'id');
+    const href = getAttr(tag, 'href');
+
+    if (id && href) {
+      items.set(id, href);
+    }
+  }
+
+  return items;
+};
+
+const getSpineHrefs = (opf: string, manifestItems: Map<string, string>, opfDir: string): string[] => {
+  const spine = opf.match(/<spine\b[\s\S]*?<\/spine>/i)?.[0] || '';
+  const itemrefRegex = /<itemref\b[^>]*>/gi;
+  const hrefs: string[] = [];
+  let itemrefMatch: RegExpExecArray | null;
+
+  while ((itemrefMatch = itemrefRegex.exec(spine))) {
+    const idref = getAttr(itemrefMatch[0], 'idref');
+    const href = idref ? manifestItems.get(idref) : '';
+
+    if (href) {
+      hrefs.push(normalizePath(joinPath(opfDir, href)));
+    }
+  }
+
+  return hrefs;
+};
+
+const parseNcx = (ncx: string, ncxDir: string): TocEntry[] => {
+  const entries: TocEntry[] = [];
+  const navPointRegex = /<navPoint\b[\s\S]*?<\/navPoint>/gi;
+  let navPointMatch: RegExpExecArray | null;
+
+  while ((navPointMatch = navPointRegex.exec(ncx))) {
+    const navPoint = navPointMatch[0];
+    const label = stripXml(navPoint.match(/<navLabel\b[\s\S]*?<\/navLabel>/i)?.[0] || '');
+    const contentTag = navPoint.match(/<content\b[^>]*>/i)?.[0] || '';
+    const src = getAttr(contentTag, 'src');
+
+    if (label && src) {
+      entries.push({ href: normalizePath(joinPath(ncxDir, src)), label });
+    }
+  }
+
+  return entries;
+};
+
+const parseNavDocument = (navDocument: string, navDir: string): TocEntry[] => {
+  const entries: TocEntry[] = [];
+  const linkRegex = /<a\b[^>]*href\s*=\s*["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi;
+  let linkMatch: RegExpExecArray | null;
+
+  while ((linkMatch = linkRegex.exec(navDocument))) {
+    const href = linkMatch[1];
+    const label = stripXml(linkMatch[2]);
+
+    if (href && label) {
+      entries.push({ href: normalizePath(joinPath(navDir, href)), label });
+    }
+  }
+
+  return entries;
+};
+
+const getTocEntries = async (
+  reader: EpubFileReader,
+  opf: string,
+  manifestItems: Map<string, string>,
+  opfDir: string,
+): Promise<TocEntry[]> => {
+  const ncxItem = Array.from(manifestItems.values()).find((href) => href.toLowerCase().endsWith('.ncx'));
+
+  if (ncxItem) {
+    const ncxPath = normalizePath(joinPath(opfDir, ncxItem));
+    const ncx = await reader.readText(ncxPath);
+    const entries = parseNcx(ncx, dirname(ncxPath));
+
+    if (entries.length > 0) {
+      return entries;
+    }
+  }
+
+  const navItem = Array.from(manifestItems.values()).find((href) => /\.(xhtml|html)$/i.test(href) && /toc|nav/i.test(href));
+
+  if (navItem) {
+    const navPath = normalizePath(joinPath(opfDir, navItem));
+    const navDocument = await reader.readText(navPath);
+    const entries = parseNavDocument(navDocument, dirname(navPath));
+
+    if (entries.length > 0) {
+      return entries;
+    }
+  }
+
+  return parseNavDocument(opf, opfDir);
+};
+
+const buildChapterMap = (spineHrefs: string[], tocEntries: TocEntry[]): Map<string, string> => {
+  const tocByHref = new Map<string, string>();
+
+  for (const entry of tocEntries) {
+    tocByHref.set(normalizePath(entry.href), entry.label);
+  }
+
+  const chapterMap = new Map<string, string>();
+  let currentChapter = '';
+
+  for (const href of spineHrefs) {
+    const label = tocByHref.get(href);
+
+    if (label) {
+      currentChapter = label;
+    }
+
+    if (currentChapter) {
+      chapterMap.set(href, currentChapter);
+    }
+  }
+
+  for (const [href, label] of tocByHref) {
+    chapterMap.set(href, label);
+  }
+
+  return chapterMap;
+};
+
+const getChapterHrefFromCfi = (location: string, spineHrefs: string[]): string => {
+  const idrefMatch = location.match(/\/6\/\d+\[([^\]]+)\]/);
+  const idref = idrefMatch?.[1] || '';
+
+  if (idref) {
+    const exactHref = spineHrefs.find((href) => {
+      const filename = href.split('/').pop() || '';
+      const basename = filename.replace(/\.[^.]+$/, '');
+
+      return basename === idref || filename === idref;
+    });
+
+    if (exactHref) {
+      return exactHref;
+    }
+  }
+
+  const spineStep = Number(location.match(/epubcfi\(\/6\/(\d+)/)?.[1] || 0);
+  const spineIndex = spineStep > 0 ? Math.floor(spineStep / 2) - 1 : -1;
+
+  return spineIndex >= 0 ? spineHrefs[spineIndex] || '' : '';
+};
+
+const buildBookChapterMap = async (book: IBookWithAnnotations): Promise<Map<string, string>> => {
+  const reader = await createReader(book.bookPath || '');
+
+  if (!reader) {
+    return new Map();
+  }
+
+  const opfPath = await findOpfPath(reader);
+
+  if (!opfPath) {
+    return new Map();
+  }
+
+  const opf = await reader.readText(opfPath);
+  const opfDir = dirname(opfPath);
+  const manifestItems = getManifestItems(opf);
+  const spineHrefs = getSpineHrefs(opf, manifestItems, opfDir);
+  const tocEntries = await getTocEntries(reader, opf, manifestItems, opfDir);
+  const chapterMap = buildChapterMap(spineHrefs, tocEntries);
+  const resolvedChapters = new Map<string, string>();
+
+  for (const annotation of book.annotations || []) {
+    const href = getChapterHrefFromCfi(annotation.highlightLocation, spineHrefs);
+    const chapter = href ? chapterMap.get(href) || '' : '';
+
+    if (chapter) {
+      resolvedChapters.set(annotation.highlightLocation, chapter);
+    }
+  }
+
+  return resolvedChapters;
+};
+
+export const inferMissingChapters = async (books: IBookWithAnnotations[]): Promise<void> => {
+  await Promise.all(
+    books.map(async (book) => {
+      if (!book.annotations.some((annotation) => !annotation.chapter)) {
+        return;
+      }
+
+      try {
+        const chapterMap = await buildBookChapterMap(book);
+
+        for (const annotation of book.annotations) {
+          annotation.chapter = annotation.chapter || chapterMap.get(annotation.highlightLocation) || '';
+        }
+      } catch (error) {
+        console.warn(`Apple Books Knowledge Cards: 无法推断章节：${book.bookTitle}`, error);
+      }
+    }),
+  );
+};

--- a/src/modules/highlightCards.ts
+++ b/src/modules/highlightCards.ts
@@ -1,0 +1,193 @@
+import type { IAnnotation, IBookWithAnnotations } from '../types';
+import type { VaultManagement } from './vaultManagement';
+
+const joinPath = (...parts: string[]): string => parts.join('/').replace(/\/+/g, '/');
+
+const simpleHash = (value: string): string => {
+  let hash = 0x811c9dc5;
+
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, '0');
+};
+
+export const getAnnotationId = (bookId: string, highlightLocation: string): string => {
+  const bookPrefix = bookId.slice(0, 8).toLowerCase();
+  const locationHash = simpleHash(highlightLocation).slice(0, 8);
+
+  return `ibooks-${bookPrefix}-${locationHash}`;
+};
+
+export const getHighlightColor = (highlightStyle: number): string => {
+  const colorMap: Record<number, string> = {
+    0: 'underline',
+    1: 'green',
+    2: 'blue',
+    3: 'yellow',
+    4: 'pink',
+    5: 'purple',
+  };
+
+  return colorMap[highlightStyle] || 'plain';
+};
+
+const escapeYamlString = (value: string | number | boolean | null | undefined): string => {
+  if (value === null || value === undefined) {
+    return '""';
+  }
+
+  return JSON.stringify(String(value));
+};
+
+const toYamlBoolean = (value: boolean): string => (value ? 'true' : 'false');
+
+const parseFrontmatter = (content: string): Record<string, string | boolean | number> => {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+
+  if (!match) {
+    return {};
+  }
+
+  const data: Record<string, string | boolean | number> = {};
+  for (const line of match[1].split('\n')) {
+    const separatorIndex = line.indexOf(':');
+
+    if (separatorIndex === -1 || line.startsWith('  - ')) {
+      continue;
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const rawValue = line.slice(separatorIndex + 1).trim();
+    const unquotedValue = rawValue.replace(/^"(.*)"$/, '$1');
+
+    if (unquotedValue === 'true') {
+      data[key] = true;
+    } else if (unquotedValue === 'false') {
+      data[key] = false;
+    } else if (/^\d+(\.\d+)?$/.test(unquotedValue)) {
+      data[key] = Number(unquotedValue);
+    } else {
+      data[key] = unquotedValue;
+    }
+  }
+
+  return data;
+};
+
+const toBlockquote = (value: string): string => {
+  if (!value) {
+    return '';
+  }
+
+  return value
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n');
+};
+
+const extractSection = (content: string, heading: string): string => {
+  const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = content.match(new RegExp(`^## ${escapedHeading}\\s*\\n([\\s\\S]*?)(?=^## |$(?![\\s\\S]))`, 'm'));
+
+  if (!match) {
+    return '';
+  }
+
+  return match[1].trim();
+};
+
+const buildSourceKey = (bookId: string, highlightLocation: string): string => {
+  return `ibooks://assetid/${bookId}#${highlightLocation}`;
+};
+
+const buildPreview = (value: string, maxLength = 120): string => {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, maxLength)}…`;
+};
+
+const buildCardContent = (book: IBookWithAnnotations, annotation: IAnnotation, highlightIndex: number, existingContent = ''): string => {
+  const annotationId = getAnnotationId(book.bookId, annotation.highlightLocation);
+  const sourceKey = buildSourceKey(book.bookId, annotation.highlightLocation);
+  const highlightColor = getHighlightColor(annotation.highlightStyle);
+  const shouldShowContext = annotation.contextualText && annotation.contextualText !== annotation.highlight;
+  const highlight = toBlockquote(annotation.highlight);
+  const context = shouldShowContext ? toBlockquote(annotation.contextualText) : '';
+  const appleNote = annotation.note ? annotation.note : '';
+  const existingAppleNote = extractSection(existingContent, '想法') || extractSection(existingContent, '我的想法');
+  const existingLocalNote = extractSection(existingContent, '笔记');
+  const localNote = existingLocalNote || (existingAppleNote && existingAppleNote !== appleNote ? existingAppleNote : '');
+  const localState = parseFrontmatter(existingContent);
+  const highlightPreview = buildPreview(annotation.highlight);
+  const favorite = typeof localState.favorite === 'boolean' ? localState.favorite : false;
+  const reviewed = typeof localState.reviewed === 'boolean' ? localState.reviewed : false;
+  const linkedAtomicNote = typeof localState.linked_atomic_note === 'string' ? localState.linked_atomic_note : '';
+
+  return `---
+type: ibooks_highlight
+book_title: ${escapeYamlString(book.bookTitle)}
+book_author: ${escapeYamlString(book.bookAuthor)}
+book_id: ${escapeYamlString(book.bookId)}
+annotation_id: ${escapeYamlString(annotationId)}
+source_key: ${escapeYamlString(sourceKey)}
+highlight_location: ${escapeYamlString(annotation.highlightLocation)}
+highlight_creation_date: ${annotation.highlightCreationDate || 0}
+highlight_modification_date: ${annotation.highlightModificationDate || 0}
+highlight_color: ${escapeYamlString(highlightColor)}
+highlight_preview: ${escapeYamlString(highlightPreview)}
+chapter: ${escapeYamlString(annotation.chapter || '')}
+highlight_index: ${highlightIndex}
+favorite: ${toYamlBoolean(favorite)}
+reviewed: ${toYamlBoolean(reviewed)}
+linked_atomic_note: ${escapeYamlString(linkedAtomicNote)}
+tags:
+  - book-highlight
+  - apple-books
+---
+
+# 摘录 ${highlightIndex}
+
+## 划线
+
+${highlight}
+${context ? `\n\n## 上下文\n\n${context}` : ''}
+${appleNote ? `\n\n## 想法\n\n${appleNote}` : '\n\n## 想法\n'}
+
+## 笔记
+
+${localNote}
+
+## 来源
+
+- 书籍：[[${book.bookTitle} - ${book.bookAuthor}|${book.bookTitle}]]
+- Apple Books：[打开原始标注](${sourceKey})
+`;
+};
+
+const getCardRelativePath = (bookFilename: string, highlightIndex: number): string => {
+  const paddedIndex = String(highlightIndex).padStart(3, '0');
+
+  return joinPath('cards', bookFilename, `摘录-${paddedIndex}.md`);
+};
+
+export const importHighlightCards = async (vault: VaultManagement, book: IBookWithAnnotations, bookFilename: string): Promise<void> => {
+  await vault.ensureFolder(joinPath(vault.getHighlightsFolder(), 'cards'));
+  await vault.ensureFolder(joinPath(vault.getHighlightsFolder(), 'cards', bookFilename));
+
+  for (const [index, annotation] of book.annotations.entries()) {
+    const displayIndex = index + 1;
+    const relativePath = getCardRelativePath(bookFilename, displayIndex);
+    const filePath = joinPath(vault.getHighlightsFolder(), relativePath);
+    const existingContent = await vault.readFileIfExists(filePath);
+    const content = buildCardContent(book, annotation, displayIndex, existingContent);
+
+    await vault.upsertFile(filePath, content);
+  }
+};

--- a/src/modules/highlightRepository.ts
+++ b/src/modules/highlightRepository.ts
@@ -1,0 +1,169 @@
+import type { App, TFile } from 'obsidian';
+import type { IBookHighlightsPluginSettings, IBookNoteSummary, IHighlightCard } from '../types';
+
+const parseFrontmatter = (content: string): Record<string, string | boolean | number> => {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+
+  if (!match) {
+    return {};
+  }
+
+  const data: Record<string, string | boolean | number> = {};
+  for (const line of match[1].split('\n')) {
+    const separatorIndex = line.indexOf(':');
+
+    if (separatorIndex === -1 || line.startsWith('  - ')) {
+      continue;
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const rawValue = line.slice(separatorIndex + 1).trim();
+    const unquotedValue = rawValue.replace(/^"(.*)"$/, '$1');
+
+    if (unquotedValue === 'true') {
+      data[key] = true;
+    } else if (unquotedValue === 'false') {
+      data[key] = false;
+    } else if (/^\d+$/.test(unquotedValue)) {
+      data[key] = Number(unquotedValue);
+    } else {
+      data[key] = unquotedValue;
+    }
+  }
+
+  return data;
+};
+
+const extractSection = (content: string, heading: string): string => {
+  const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = content.match(new RegExp(`^## ${escapedHeading}\\s*\\n([\\s\\S]*?)(?=^## |$(?![\\s\\S]))`, 'm'));
+
+  if (!match) {
+    return '';
+  }
+
+  return match[1].replace(/^> ?/gm, '').trim();
+};
+
+const updateFrontmatterValue = (content: string, key: string, value: string): string => {
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+
+  if (!frontmatterMatch) {
+    return content;
+  }
+
+  const frontmatter = frontmatterMatch[1];
+  const keyRegex = new RegExp(`^${key}:.*$`, 'm');
+  const updatedFrontmatter = keyRegex.test(frontmatter)
+    ? frontmatter.replace(keyRegex, `${key}: ${value}`)
+    : `${frontmatter}\n${key}: ${value}`;
+
+  return content.replace(/^---\n[\s\S]*?\n---/, `---\n${updatedFrontmatter}\n---`);
+};
+
+const setSection = (content: string, heading: string, value: string): string => {
+  const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const sectionRegex = new RegExp(`## ${escapedHeading}\\n\\n[\\s\\S]*?(?=\\n## |$)`);
+  const normalizedValue = value.trim();
+  const replacement = `## ${heading}\n\n${normalizedValue}`;
+
+  if (sectionRegex.test(content)) {
+    return content.replace(sectionRegex, replacement);
+  }
+
+  return `${content.trim()}\n\n${replacement}\n`;
+};
+
+const getCardFile = (app: App, path: string): TFile => {
+  const file = app.vault.getFileByPath(path);
+
+  if (!file) {
+    throw new Error(`找不到摘录文件：${path}`);
+  }
+
+  return file;
+};
+
+export const getHighlightCards = async (app: App, settings: IBookHighlightsPluginSettings): Promise<IHighlightCard[]> => {
+  const cardsRoot = `${settings.highlightsFolder}/cards/`;
+  const files = app.vault.getMarkdownFiles().filter((file) => file.path.startsWith(cardsRoot));
+
+  const cards = await Promise.all(
+    files.map(async (file: TFile) => {
+      const content = await app.vault.cachedRead(file);
+      const frontmatter = parseFrontmatter(content);
+
+      return {
+        path: file.path,
+        bookTitle: String(frontmatter.book_title || ''),
+        bookAuthor: String(frontmatter.book_author || ''),
+        bookId: String(frontmatter.book_id || ''),
+        annotationId: String(frontmatter.annotation_id || ''),
+        sourceKey: String(frontmatter.source_key || ''),
+        highlightLocation: String(frontmatter.highlight_location || ''),
+        highlightCreationDate: Number(frontmatter.highlight_creation_date || 0),
+        highlightModificationDate: Number(frontmatter.highlight_modification_date || 0),
+        highlightColor: String(frontmatter.highlight_color || 'plain'),
+        chapter: String(frontmatter.chapter || ''),
+        highlightIndex: Number(frontmatter.highlight_index || 0),
+        favorite: Boolean(frontmatter.favorite),
+        reviewed: Boolean(frontmatter.reviewed),
+        linkedAtomicNote: String(frontmatter.linked_atomic_note || ''),
+        highlight: extractSection(content, '划线'),
+        appleNote: extractSection(content, '想法') || extractSection(content, '我的想法'),
+        localNote: extractSection(content, '笔记'),
+      };
+    }),
+  );
+
+  return cards.sort((a, b) => {
+    const bookComparison = a.bookTitle.localeCompare(b.bookTitle);
+
+    if (bookComparison !== 0) {
+      return bookComparison;
+    }
+
+    return a.highlightIndex - b.highlightIndex;
+  });
+};
+
+export const getBookSummaries = async (app: App, settings: IBookHighlightsPluginSettings): Promise<IBookNoteSummary[]> => {
+  const bookFilesRoot = `${settings.highlightsFolder}/`;
+  const cardsRoot = `${settings.highlightsFolder}/cards/`;
+  const files = app.vault.getMarkdownFiles().filter((file) => file.path.startsWith(bookFilesRoot) && !file.path.startsWith(cardsRoot));
+
+  const books = await Promise.all(
+    files.map(async (file: TFile) => {
+      const content = await app.vault.cachedRead(file);
+      const frontmatter = parseFrontmatter(content);
+
+      return {
+        path: file.path,
+        title: String(frontmatter.title || file.basename),
+        author: String(frontmatter.author || ''),
+        bookId: String(frontmatter.book_id || ''),
+        annotationCount: Number(frontmatter.annotation_count || 0),
+        status: String(frontmatter.status || ''),
+        cover: String(frontmatter.cover || ''),
+      };
+    }),
+  );
+
+  return books.sort((a, b) => b.annotationCount - a.annotationCount);
+};
+
+export const setHighlightFavorite = async (app: App, card: IHighlightCard, favorite: boolean): Promise<void> => {
+  const file = getCardFile(app, card.path);
+  const content = await app.vault.read(file);
+  const updatedContent = updateFrontmatterValue(content, 'favorite', favorite ? 'true' : 'false');
+
+  await app.vault.modify(file, updatedContent);
+};
+
+export const setHighlightLocalNote = async (app: App, card: IHighlightCard, note: string): Promise<void> => {
+  const file = getCardFile(app, card.path);
+  const content = await app.vault.read(file);
+  const updatedContent = setSection(content, '笔记', note);
+
+  await app.vault.modify(file, updatedContent);
+};

--- a/src/modules/templateProcessing.ts
+++ b/src/modules/templateProcessing.ts
@@ -33,3 +33,11 @@ Handlebars.registerHelper('dateFormat', (date, format) => {
 
   return formattedDate;
 });
+
+Handlebars.registerHelper('padIndex', (index) => {
+  return String(index).padStart(3, '0');
+});
+
+Handlebars.registerHelper('displayIndex', (index) => {
+  return Number(index) + 1;
+});

--- a/src/modules/vaultManagement.ts
+++ b/src/modules/vaultManagement.ts
@@ -1,6 +1,7 @@
 import type { App, Vault, TFolder, TFile } from 'obsidian';
-import path from 'path';
 import type { IBookHighlightsPluginSettings } from '../types';
+
+const joinPath = (...parts: string[]): string => parts.join('/').replace(/\/+/g, '/');
 
 export class VaultManagement {
   private app: App;
@@ -24,7 +25,7 @@ export class VaultManagement {
   }
 
   getFilePath(filenameTemplate: string): TFile | null {
-    const filePath = path.join(this.getHighlightsFolder(), `${filenameTemplate}.md`);
+    const filePath = joinPath(this.getHighlightsFolder(), `${filenameTemplate}.md`);
 
     const result = this.vault.getFileByPath(filePath);
 
@@ -39,14 +40,48 @@ export class VaultManagement {
     }
   }
 
+  async ensureFolder(folderPath: string): Promise<void> {
+    const normalizedParts = folderPath.split('/').filter(Boolean);
+    let currentPath = '';
+
+    for (const part of normalizedParts) {
+      currentPath = currentPath ? joinPath(currentPath, part) : part;
+
+      if (!this.vault.getFolderByPath(currentPath)) {
+        await this.vault.createFolder(currentPath);
+      }
+    }
+  }
+
   async createBookFile(filename: string, content: string): Promise<void> {
-    const filePath = path.join(this.getHighlightsFolder(), `${filename}.md`);
+    const filePath = joinPath(this.getHighlightsFolder(), `${filename}.md`);
 
     await this.vault.create(filePath, content);
   }
 
   async modifyBookFile(file: TFile, content: string): Promise<void> {
     await this.vault.modify(file, content);
+  }
+
+  async upsertFile(filePath: string, content: string): Promise<void> {
+    const existingFile = this.vault.getFileByPath(filePath);
+
+    if (existingFile) {
+      await this.vault.modify(existingFile, content);
+      return;
+    }
+
+    await this.vault.create(filePath, content);
+  }
+
+  async readFileIfExists(filePath: string): Promise<string> {
+    const existingFile = this.vault.getFileByPath(filePath);
+
+    if (!existingFile) {
+      return '';
+    }
+
+    return this.vault.cachedRead(existingFile);
   }
 
   async backupAllHighlights(): Promise<void> {
@@ -64,6 +99,6 @@ export class VaultManagement {
 
   async backupBookFile(file: TFile): Promise<void> {
     const backupFileName = `${file.basename}-bk-${Date.now()}.md`;
-    await this.vault.adapter.rename(file.path, path.join(this.getHighlightsFolder(), backupFileName));
+    await this.vault.adapter.rename(file.path, joinPath(this.getHighlightsFolder(), backupFileName));
   }
 }

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -2,24 +2,36 @@ import { type App, Notice, PluginSettingTab, Setting } from 'obsidian';
 import type IBookHighlightsPlugin from '../../main';
 import { type IBookHighlightsPluginSettings, IHighlightsSortingCriterion } from '../types';
 
-export const defaultTemplate = `Title:: 📕 {{{bookTitle}}}
-Author:: {{{bookAuthor}}}
-Link:: [Apple Books Link](ibooks://assetid/{{bookId}})
+export const defaultTemplate = `---
+type: book
+title: "{{{bookTitle}}}"
+author: "{{{bookAuthor}}}"
+source: Apple Books
+book_id: "{{bookId}}"
+annotation_count: {{annotations.length}}
+status: "{{#if bookFinishedDate}}已读{{else}}在读{{/if}}"
+cover: "[[附件/书封/{{{bookTitle}}} - {{{bookAuthor}}}.jpg]]"
+cssclasses:
+  - wide-apple-book
+tags:
+  - book
+---
 
-## Annotations
-
-Number of annotations:: {{annotations.length}}
-
+<details class="abkc-note-toc-details">
+<summary>摘录目录</summary>
+<div class="abkc-note-toc">
 {{#each annotations}}
-----
-
-- 📖 Chapter:: {{#if chapter}}{{{chapter}}}{{else}}N/A{{/if}}
-- 🔖 Context:: {{#if contextualText}}{{{contextualText}}}{{else}}N/A{{/if}}
-- 🎯 Highlight:: {{{highlight}}}
-- 📝 Note:: {{#if note}}{{{note}}}{{else}}N/A{{/if}}
-- 📙 Highlight Link:: {{#if highlightLocation}}[Apple Books Highlight Link](ibooks://assetid/{{../bookId}}#{{highlightLocation}}){{else}}N/A{{/if}}
-
+<a href="#摘录-{{displayIndex @index}}">摘录 {{displayIndex @index}}</a>
 {{/each}}
+</div>
+</details>
+
+## 本书摘录
+
+\`\`\`apple-books-board
+book_id: {{bookId}}
+theme: receipt
+\`\`\`
 `;
 
 const allowedFilenameTemplateVariables = [
@@ -31,7 +43,7 @@ const allowedFilenameTemplateVariables = [
 ];
 
 export const defaultPluginSettings: IBookHighlightsPluginSettings = {
-  highlightsFolder: 'ibooks-highlights',
+  highlightsFolder: '10 Sources/ibooks-dev',
   backup: false,
   importOnStart: false,
   highlightsSortingCriterion: 'creationDateOldToNew',
@@ -68,13 +80,13 @@ export class IBookHighlightsSettingTab extends PluginSettingTab {
 
   addHighlightsFolderSetting(containerEl: HTMLElement): void {
     const folder = new Setting(containerEl)
-      .setName('Highlights folder')
-      .setDesc('A folder (within the root of your vault) where you want to save imported highlights')
+      .setName('导入目录')
+      .setDesc('保存 Apple Books 书籍主笔记和摘录卡片的 Vault 内目录。')
       .setClass('ibooks-highlights-folder');
 
     folder.addText((text) =>
       text
-        .setPlaceholder('Folder to save highlights')
+        .setPlaceholder('保存导入内容的目录')
         .setValue(this.plugin.settings.highlightsFolder)
         .onChange(async (value) => {
           if (!value) {
@@ -92,8 +104,8 @@ export class IBookHighlightsSettingTab extends PluginSettingTab {
 
   addImportOnStartSetting(containerEl: HTMLElement): void {
     new Setting(containerEl)
-      .setName('Import highlights on start')
-      .setDesc('Import all highlights from all your books when Obsidian starts (requires confirmation on each start if backup is disabled)')
+      .setName('启动时导入')
+      .setDesc('Obsidian 启动时自动导入所有 Apple Books 摘录。')
       .addToggle((toggle) => {
         toggle.setValue(this.plugin.settings.importOnStart).onChange(async (value) => {
           this.plugin.settings.importOnStart = value;
@@ -105,21 +117,21 @@ export class IBookHighlightsSettingTab extends PluginSettingTab {
 
   addBackupSetting(containerEl: HTMLElement): void {
     new Setting(containerEl)
-      .setName('Backup highlights')
+      .setName('导入前备份')
       .setDesc(
         createFragment((el) => {
-          el.appendText('Backup highlights before import.');
+          el.appendText('导入前备份已有摘录。');
           el.createEl('br');
-          el.appendText('- Folder template: <highlights-folder>-bk-<timestamp> (For example, ibooks-highlights-bk-1704060001).');
+          el.appendText('- 文件夹格式：<导入目录>-bk-<时间戳>');
           el.createEl('br');
-          el.appendText('- File template: <highlights-file>-bk-<timestamp> (For example, Building a Second Brain-bk-1704060001).');
+          el.appendText('- 文件格式：<书籍文件>-bk-<时间戳>');
         }),
       )
       .addToggle((toggle) => {
         toggle.setValue(this.plugin.settings.backup).onChange(async (value) => {
           if (!value) {
             // oxlint-disable-next-line
-            new Notice('Disabling backups imposes a risk of data loss. Please use with caution.', 0);
+            new Notice('关闭备份可能带来数据丢失风险，请谨慎使用。', 0);
           }
           this.plugin.settings.backup = value;
 
@@ -130,16 +142,16 @@ export class IBookHighlightsSettingTab extends PluginSettingTab {
 
   addHighlightsSortingCriterionSetting(containerEl: HTMLElement): void {
     new Setting(containerEl)
-      .setName('Highlights sorting criterion')
-      .setDesc('Sort highlights by a specific criterion. Default: By creation date (from oldest to newest)')
+      .setName('摘录排序方式')
+      .setDesc('导入时如何排序摘录。默认建议使用“按书中位置”。')
       .setClass('ibooks-highlights-sorting')
       .addDropdown((dropdown) => {
         const options: Record<IHighlightsSortingCriterion, string> = {
-          creationDateOldToNew: 'By creation date (from oldest to newest)',
-          creationDateNewToOld: 'By creation date (from newest to oldest)',
-          lastModifiedDateOldToNew: 'By modification date (from oldest to newest)',
-          lastModifiedDateNewToOld: 'By modification date (from newest to oldest)',
-          book: 'By location in a book',
+          creationDateOldToNew: '按创建时间：从旧到新',
+          creationDateNewToOld: '按创建时间：从新到旧',
+          lastModifiedDateOldToNew: '按修改时间：从旧到新',
+          lastModifiedDateNewToOld: '按修改时间：从新到旧',
+          book: '按书中位置',
         };
 
         dropdown
@@ -155,12 +167,12 @@ export class IBookHighlightsSettingTab extends PluginSettingTab {
 
   addTemplateSetting(containerEl: HTMLElement): void {
     new Setting(containerEl)
-      .setName('Template')
-      .setDesc('Template for highlight files')
+      .setName('书籍主笔记模板')
+      .setDesc('用于生成每本书主笔记的模板。独立摘录卡片由插件自动生成。')
       .setClass('ibooks-highlights-template')
       .addTextArea((text) => {
         text
-          .setPlaceholder('Template')
+          .setPlaceholder('书籍主笔记模板')
           .setValue(this.plugin.settings.template)
           .onChange(async (value) => {
             const valueToSet = value === '' ? defaultTemplate : value;
@@ -174,12 +186,12 @@ export class IBookHighlightsSettingTab extends PluginSettingTab {
 
   addFilenameTemplateSetting(containerEl: HTMLElement): void {
     const filenameTemplate = new Setting(containerEl)
-      .setName('Template for naming highlight files')
+      .setName('书籍主笔记文件名模板')
       .setDesc(
         createFragment((el) => {
-          el.appendText('Template to generate the name of highlight files.');
+          el.appendText('用于生成书籍主笔记文件名的模板。');
           el.createEl('br');
-          el.appendText('The following template variables are available:');
+          el.appendText('可用变量：');
 
           const ul = el.createEl('ul');
           for (const allowedVariable of allowedFilenameTemplateVariables) {
@@ -189,14 +201,14 @@ export class IBookHighlightsSettingTab extends PluginSettingTab {
           }
           el.createEl('br');
           // The first variable is the default one
-          el.appendText(`Default: ${defaultPluginSettings.filenameTemplate}`);
+          el.appendText(`默认：${defaultPluginSettings.filenameTemplate}`);
         }),
       )
       .setClass('ibooks-highlights-file-naming-template');
 
     filenameTemplate.addTextArea((text) => {
       text
-        .setPlaceholder('Naming template for highlight files')
+        .setPlaceholder('书籍主笔记文件名模板')
         .setValue(this.plugin.settings.filenameTemplate)
         .onChange(async (value) => {
           const valueToSet = value === '' ? defaultPluginSettings.filenameTemplate : value;
@@ -210,12 +222,12 @@ export class IBookHighlightsSettingTab extends PluginSettingTab {
 
   addKeepMeSectionSetting(containerEl: HTMLElement): void {
     new Setting(containerEl)
-      .setName('Template: Keep Me section')
+      .setName('模板：保留区')
       .setDesc(
         createFragment((el) => {
-          el.appendText('Section that keeps your information from being overwritten during re-imports.');
+          el.appendText('重新导入时不会被覆盖的内容区域。');
           el.createEl('br');
-          el.appendText('Default delimiters:');
+          el.appendText('默认分隔符：');
           const ul = el.createEl('ul');
           ul.createEl('li', { text: 'Opening: %% keep-me %%' });
           ul.createEl('li', { text: 'Closing: %% /keep-me %%' });
@@ -224,7 +236,7 @@ export class IBookHighlightsSettingTab extends PluginSettingTab {
       .setClass('ibooks-highlights-keep-me-section')
       .addText((text) => {
         text
-          .setPlaceholder('Opening delimiter')
+          .setPlaceholder('开始分隔符')
           .setValue(this.plugin.settings.keepMeSectionOpeningDelimiter || defaultPluginSettings.keepMeSectionOpeningDelimiter)
           .onChange(async (value) => {
             const valueToSet = value === '' ? defaultPluginSettings.keepMeSectionOpeningDelimiter : value;
@@ -236,7 +248,7 @@ export class IBookHighlightsSettingTab extends PluginSettingTab {
       })
       .addText((text) => {
         text
-          .setPlaceholder('Closing delimiter')
+          .setPlaceholder('结束分隔符')
           .setValue(this.plugin.settings.keepMeSectionClosingDelimiter || defaultPluginSettings.keepMeSectionClosingDelimiter)
           .onChange(async (value) => {
             const valueToSet = value === '' ? defaultPluginSettings.keepMeSectionClosingDelimiter : value;
@@ -250,10 +262,10 @@ export class IBookHighlightsSettingTab extends PluginSettingTab {
 
   addResetTemplateSetting(containerEl: HTMLElement): void {
     new Setting(containerEl)
-      .setName('Reset template')
-      .setDesc('Reset template to default')
+      .setName('重置模板')
+      .setDesc('将书籍主笔记模板恢复为默认值。')
       .addButton((button) => {
-        button.setButtonText('Reset template').onClick(async () => {
+        button.setButtonText('重置模板').onClick(async () => {
           this.plugin.settings.template = defaultTemplate;
 
           await this.plugin.saveSettings();
@@ -266,7 +278,7 @@ export class IBookHighlightsSettingTab extends PluginSettingTab {
     containerEl.createEl('hr');
     containerEl
       .createEl('small', {
-        text: 'Created by ',
+        text: '基于原插件作者：',
         cls: 'credits',
       })
       .createEl('a', {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@ export interface IBook {
   bookLastOpenedDate: number;
   bookFinishedDate: number | null;
   bookCoverUrl: string;
+  bookPath?: string;
 }
 
 export interface IAnnotation {
@@ -44,4 +45,35 @@ export interface IBookHighlightsPluginSettings {
   keepMeSectionOpeningDelimiter: string;
   keepMeSectionClosingDelimiter: string;
   keepMeSectionData?: Record<string, string>;
+}
+
+export interface IHighlightCard {
+  path: string;
+  bookTitle: string;
+  bookAuthor: string;
+  bookId: string;
+  annotationId: string;
+  sourceKey: string;
+  highlightLocation: string;
+  highlightCreationDate: number;
+  highlightModificationDate: number;
+  highlightColor: string;
+  chapter: string;
+  highlightIndex: number;
+  favorite: boolean;
+  reviewed: boolean;
+  linkedAtomicNote: string;
+  highlight: string;
+  appleNote: string;
+  localNote: string;
+}
+
+export interface IBookNoteSummary {
+  path: string;
+  title: string;
+  author: string;
+  bookId: string;
+  annotationCount: number;
+  status: string;
+  cover: string;
 }

--- a/src/utils/databaseQuery.ts
+++ b/src/utils/databaseQuery.ts
@@ -1,6 +1,7 @@
-import { spawn } from 'child_process';
+import { requireNodeModule } from './nodeModules';
 
 export const executeDbQuery = async <T>(dbPath: string, sqlQuery: string): Promise<T> => {
+  const { spawn } = requireNodeModule<typeof import('child_process')>('child_process');
   const dbQueryResult = spawn('sqlite3', [dbPath, sqlQuery, '-json']);
 
   const chunks: Buffer[] = [];

--- a/src/utils/nodeModules.ts
+++ b/src/utils/nodeModules.ts
@@ -1,0 +1,23 @@
+type NodeRequire = <T = unknown>(specifier: string) => T;
+
+declare const require: NodeRequire | undefined;
+
+export const requireNodeModule = <T>(specifier: string): T => {
+  if (typeof require === 'function') {
+    return require<T>(specifier);
+  }
+
+  const requireFromGlobal = globalThis.require as NodeRequire | undefined;
+
+  if (typeof requireFromGlobal === 'function') {
+    return requireFromGlobal<T>(specifier);
+  }
+
+  const requireFromWindow = (globalThis as { window?: { require?: NodeRequire } }).window?.require;
+
+  if (typeof requireFromWindow === 'function') {
+    return requireFromWindow<T>(specifier);
+  }
+
+  throw new Error(`当前运行环境无法加载 Node 模块“${specifier}”。请在 macOS 桌面版 Obsidian 中执行 Apple Books 导入。`);
+};

--- a/src/utils/notificationCenter.ts
+++ b/src/utils/notificationCenter.ts
@@ -1,11 +1,11 @@
 import { Notice } from 'obsidian';
 
 export const showSuccessfulImportNotice = (): Notice => {
-  return new Notice('Apple Books highlights imported successfully');
+  return new Notice('Apple Books 摘录导入成功');
 };
 
 export const showFailedImportNotice = (pluginName: string): Notice => {
-  return new Notice(`[${pluginName}]:\nError importing highlights. Check console for details (⌥ ⌘ I)`, 0);
+  return new Notice(`[${pluginName}]:\n导入摘录失败，请打开开发者控制台查看详情（⌥ ⌘ I）`, 0);
 };
 
 export const showErrorInConsole = (pluginName: string, error: unknown): void => {

--- a/src/views/cardRenderer.ts
+++ b/src/views/cardRenderer.ts
@@ -1,0 +1,580 @@
+import { Modal, Notice, Platform, Setting, type App } from 'obsidian';
+import type { IHighlightCard } from '../types';
+import { setHighlightFavorite, setHighlightLocalNote } from '../modules/highlightRepository';
+
+interface BoardFilters {
+  bookId?: string;
+}
+
+interface ToolbarOptions {
+  initialBookTitle?: string;
+  initialOnlyFavorite?: boolean;
+  initialOnlyUnreviewed?: boolean;
+  initialOnlyWithAppleNote?: boolean;
+  initialOnlyWithChapter?: boolean;
+}
+
+interface RenderContext {
+  onRefresh: () => Promise<void>;
+  initialOnlyFavorite?: boolean;
+  initialOnlyUnreviewed?: boolean;
+  initialOnlyWithAppleNote?: boolean;
+  initialOnlyWithChapter?: boolean;
+}
+
+interface ToolbarState {
+  query: string;
+  bookTitle: string;
+  bookAuthor: string;
+  chapter: string;
+  color: string;
+  onlyFavorite: boolean;
+  onlyUnreviewed: boolean;
+  onlyWithAppleNote: boolean;
+  onlyWithChapter: boolean;
+}
+
+const boundTocDocuments = new WeakSet<Document>();
+
+const colorLabelMap: Record<string, string> = {
+  underline: '下划线',
+  green: '绿色',
+  blue: '蓝色',
+  yellow: '黄色',
+  pink: '粉色',
+  purple: '紫色',
+  plain: '普通',
+};
+
+const showNotice = (message: string): void => {
+  const notice = new Notice(message);
+  void notice;
+};
+
+const applyFilters = (cards: IHighlightCard[], filters: BoardFilters): IHighlightCard[] => {
+  return cards.filter((card) => {
+    if (filters.bookId && card.bookId !== filters.bookId) {
+      return false;
+    }
+
+    return true;
+  });
+};
+
+const getBookTitleFromFilter = (cards: IHighlightCard[], filters: BoardFilters): string => {
+  if (!filters.bookId) {
+    return '';
+  }
+
+  return cards.find((card) => card.bookId === filters.bookId)?.bookTitle || '';
+};
+
+const getUniqueValues = (cards: IHighlightCard[], getValue: (card: IHighlightCard) => string): string[] => {
+  return Array.from(new Set(cards.map(getValue).filter(Boolean))).sort((a, b) => a.localeCompare(b));
+};
+
+const applyToolbarState = (cards: IHighlightCard[], state: ToolbarState): IHighlightCard[] => {
+  let filteredCards = cards;
+
+  if (state.query) {
+    filteredCards = filteredCards.filter((card) => {
+      return [card.highlight, card.appleNote, card.localNote, card.bookTitle, card.bookAuthor, card.chapter]
+        .join('\n')
+        .toLowerCase()
+        .includes(state.query);
+    });
+  }
+
+  if (state.bookTitle) {
+    filteredCards = filteredCards.filter((card) => card.bookTitle === state.bookTitle);
+  }
+
+  if (state.bookAuthor) {
+    filteredCards = filteredCards.filter((card) => card.bookAuthor === state.bookAuthor);
+  }
+
+  if (state.chapter) {
+    filteredCards = filteredCards.filter((card) => card.chapter === state.chapter);
+  }
+
+  if (state.color) {
+    filteredCards = filteredCards.filter((card) => card.highlightColor === state.color);
+  }
+
+  if (state.onlyFavorite) {
+    filteredCards = filteredCards.filter((card) => card.favorite);
+  }
+
+  if (state.onlyUnreviewed) {
+    filteredCards = filteredCards.filter((card) => !card.reviewed);
+  }
+
+  if (state.onlyWithAppleNote) {
+    filteredCards = filteredCards.filter((card) => card.appleNote.trim());
+  }
+
+  if (state.onlyWithChapter) {
+    filteredCards = filteredCards.filter((card) => card.chapter.trim());
+  }
+
+  return filteredCards;
+};
+
+const renderInlineHighlight = (container: HTMLElement, text: string): void => {
+  const lines = text.split('\n');
+
+  lines.forEach((line, index) => {
+    if (index > 0) {
+      container.createEl('br');
+    }
+
+    container.createSpan({ text: line, cls: 'abkc-highlight-text' });
+  });
+};
+
+const getTocHighlightIndex = (link: HTMLAnchorElement): string | null => {
+  const hrefIndex = decodeURIComponent(link.getAttribute('href') || '').match(/摘录-?(\d+)/)?.[1];
+
+  if (hrefIndex) {
+    return hrefIndex;
+  }
+
+  return link.textContent?.match(/\d+/)?.[0] || null;
+};
+
+const focusCard = (target: HTMLElement): void => {
+  target.scrollIntoView({
+    block: 'center',
+    inline: 'nearest',
+    behavior: 'smooth',
+  });
+  target.classList.add('abkc-card-focus');
+  window.setTimeout(() => {
+    target.classList.remove('abkc-card-focus');
+  }, 1400);
+};
+
+const getTocScope = (link: HTMLAnchorElement): ParentNode => {
+  return link.closest('.markdown-preview-view, .markdown-rendered, .markdown-source-view, .workspace-leaf-content') || link.ownerDocument;
+};
+
+const bindNoteToc = (container: HTMLElement): void => {
+  const doc = container.ownerDocument;
+
+  if (boundTocDocuments.has(doc)) {
+    return;
+  }
+
+  boundTocDocuments.add(doc);
+
+  doc.addEventListener(
+    'click',
+    (event) => {
+      const link = (event.target as HTMLElement | null)?.closest<HTMLAnchorElement>('.abkc-note-toc a, a[href^="#摘录"]');
+
+      if (!link) {
+        return;
+      }
+
+      const highlightIndex = getTocHighlightIndex(link);
+
+      if (!highlightIndex) {
+        return;
+      }
+
+      const scope = getTocScope(link);
+      const target =
+        scope.querySelector<HTMLElement>(`.abkc-root [data-highlight-index="${CSS.escape(highlightIndex)}"]`) ||
+        doc.querySelector<HTMLElement>(`.abkc-root [data-highlight-index="${CSS.escape(highlightIndex)}"]`);
+
+      if (!target) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      focusCard(target);
+    },
+    true,
+  );
+};
+
+const createSelect = (
+  container: HTMLElement,
+  placeholder: string,
+  values: string[],
+  onChange: (value: string) => void,
+): HTMLSelectElement => {
+  const select = container.createEl('select', { cls: 'abkc-select' });
+  select.createEl('option', { text: placeholder, value: '' });
+
+  for (const value of values) {
+    select.createEl('option', { text: value, value });
+  }
+
+  select.addEventListener('change', () => {
+    onChange(select.value);
+  });
+
+  return select;
+};
+
+const setSelectOptions = (select: HTMLSelectElement, placeholder: string, values: string[]): void => {
+  const previousValue = select.value;
+
+  select.empty();
+  select.createEl('option', { text: placeholder, value: '' });
+
+  for (const value of values) {
+    select.createEl('option', { text: value, value });
+  }
+
+  select.value = values.includes(previousValue) ? previousValue : '';
+};
+
+const createToggle = (container: HTMLElement, label: string, onChange: (enabled: boolean) => void): HTMLLabelElement => {
+  const wrapper = container.createEl('label', { cls: 'abkc-toggle' });
+  const checkbox = wrapper.createEl('input', {
+    attr: {
+      type: 'checkbox',
+    },
+  });
+  wrapper.createSpan({ text: label });
+  checkbox.addEventListener('change', () => {
+    onChange(checkbox.checked);
+  });
+
+  return wrapper;
+};
+
+const renderToolbar = (
+  container: HTMLElement,
+  cards: IHighlightCard[],
+  onFilter: (filteredCards: IHighlightCard[]) => void,
+  filters: BoardFilters,
+  options: ToolbarOptions = {},
+) => {
+  const toolbar = container.createDiv({ cls: 'abkc-toolbar' });
+  const searchGroup = toolbar.createDiv({ cls: 'abkc-toolbar-group abkc-toolbar-search-group' });
+  const filtersGroup = toolbar.createDiv({ cls: 'abkc-toolbar-group abkc-toolbar-filters-group' });
+  const togglesGroup = toolbar.createDiv({ cls: 'abkc-toolbar-group abkc-toolbar-toggles-group' });
+  const actionsGroup = toolbar.createDiv({ cls: 'abkc-toolbar-group abkc-toolbar-actions-group' });
+  const state: ToolbarState = {
+    query: '',
+    bookTitle: options.initialBookTitle || '',
+    bookAuthor: '',
+    chapter: '',
+    color: '',
+    onlyFavorite: Boolean(options.initialOnlyFavorite),
+    onlyUnreviewed: Boolean(options.initialOnlyUnreviewed),
+    onlyWithAppleNote: Boolean(options.initialOnlyWithAppleNote),
+    onlyWithChapter: Boolean(options.initialOnlyWithChapter),
+  };
+  const searchInput = searchGroup.createEl('input', {
+    cls: 'abkc-search',
+    attr: {
+      type: 'search',
+      placeholder: '搜索摘录、书名、作者、章节',
+    },
+  });
+  const getChapterSourceCards = (): IHighlightCard[] => {
+    return cards.filter((card) => {
+      if (state.bookTitle && card.bookTitle !== state.bookTitle) {
+        return false;
+      }
+
+      if (state.bookAuthor && card.bookAuthor !== state.bookAuthor) {
+        return false;
+      }
+
+      return true;
+    });
+  };
+
+  const updateChapterOptions = () => {
+    setSelectOptions(
+      chapterSelect,
+      '全部章节',
+      getUniqueValues(getChapterSourceCards(), (card) => card.chapter),
+    );
+    state.chapter = chapterSelect.value;
+  };
+
+  const bookSelect = createSelect(
+    filtersGroup,
+    '全部书籍',
+    getUniqueValues(cards, (card) => card.bookTitle),
+    (value) => {
+      state.bookTitle = value;
+      updateChapterOptions();
+      runFilter();
+    },
+  );
+  bookSelect.value = state.bookTitle;
+  const authorSelect = createSelect(
+    filtersGroup,
+    '全部作者',
+    getUniqueValues(cards, (card) => card.bookAuthor),
+    (value) => {
+      state.bookAuthor = value;
+      updateChapterOptions();
+      runFilter();
+    },
+  );
+  const chapterSelect = createSelect(
+    filtersGroup,
+    '全部章节',
+    getUniqueValues(getChapterSourceCards(), (card) => card.chapter),
+    (value) => {
+      state.chapter = value;
+      runFilter();
+    },
+  );
+  const colorSelect = createSelect(filtersGroup, '全部颜色', Object.values(colorLabelMap), () => {});
+  colorSelect.empty();
+  colorSelect.createEl('option', { text: '全部颜色', value: '' });
+  for (const [value, label] of Object.entries(colorLabelMap)) {
+    colorSelect.createEl('option', { text: label, value });
+  }
+  colorSelect.addEventListener('change', () => {
+    state.color = colorSelect.value;
+    runFilter();
+  });
+  const favoriteToggle = createToggle(togglesGroup, '只看收藏', (enabled) => {
+    state.onlyFavorite = enabled;
+    runFilter();
+  });
+  favoriteToggle.querySelector<HTMLInputElement>('input')!.checked = state.onlyFavorite;
+  const unreviewedToggle = createToggle(togglesGroup, '只看未整理', (enabled) => {
+    state.onlyUnreviewed = enabled;
+    runFilter();
+  });
+  unreviewedToggle.querySelector<HTMLInputElement>('input')!.checked = state.onlyUnreviewed;
+
+  const randomButton = actionsGroup.createEl('button', {
+    text: '随机一组',
+    cls: 'abkc-button',
+  });
+  const runFilter = () => {
+    state.query = searchInput.value.trim().toLowerCase();
+    onFilter(applyToolbarState(cards, state));
+  };
+
+  searchInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      runFilter();
+    }
+  });
+  randomButton.addEventListener('click', () => {
+    const filteredCards = applyToolbarState(cards, state);
+    const shuffledCards = [...filteredCards].sort(() => Math.random() - 0.5).slice(0, 12);
+    onFilter(shuffledCards);
+  });
+  const resetButton = actionsGroup.createEl('button', {
+    text: '重置筛选',
+    cls: 'abkc-button',
+  });
+  resetButton.addEventListener('click', () => {
+    state.query = '';
+    state.bookTitle = options.initialBookTitle || '';
+    state.bookAuthor = '';
+    state.chapter = '';
+    state.color = '';
+    state.onlyFavorite = Boolean(options.initialOnlyFavorite);
+    state.onlyUnreviewed = Boolean(options.initialOnlyUnreviewed);
+    state.onlyWithAppleNote = Boolean(options.initialOnlyWithAppleNote);
+    state.onlyWithChapter = Boolean(options.initialOnlyWithChapter);
+    searchInput.value = '';
+    bookSelect.value = state.bookTitle;
+    authorSelect.value = '';
+    colorSelect.value = '';
+    favoriteToggle.querySelector<HTMLInputElement>('input')!.checked = state.onlyFavorite;
+    unreviewedToggle.querySelector<HTMLInputElement>('input')!.checked = state.onlyUnreviewed;
+    updateChapterOptions();
+    onFilter(applyToolbarState(cards, state));
+  });
+};
+
+class EditNoteModal extends Modal {
+  private card: IHighlightCard;
+  private onSave: (note: string) => Promise<void>;
+
+  constructor(app: App, card: IHighlightCard, onSave: (note: string) => Promise<void>) {
+    super(app);
+    this.card = card;
+    this.onSave = onSave;
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.createEl('h2', { text: `编辑笔记：摘录 ${this.card.highlightIndex}` });
+    contentEl.createEl('p', { text: this.card.bookTitle, cls: 'abkc-modal-muted' });
+    const textarea = contentEl.createEl('textarea', { cls: 'abkc-note-editor' });
+    textarea.value = this.card.localNote;
+
+    new Setting(contentEl)
+      .addButton((button) => {
+        button
+          .setButtonText('保存')
+          .setCta()
+          .onClick(async () => {
+            await this.onSave(textarea.value);
+            this.close();
+          });
+      })
+      .addButton((button) => {
+        button.setButtonText('取消').onClick(() => {
+          this.close();
+        });
+      });
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}
+
+const renderCard = (app: App, board: HTMLElement, card: IHighlightCard, context: RenderContext) => {
+  const cardEl = board.createEl('article', {
+    cls: `abkc-card abkc-card-${card.highlightColor}`,
+    attr: {
+      id: card.annotationId,
+      'data-annotation-id': card.annotationId,
+      'data-highlight-index': String(card.highlightIndex),
+    },
+  });
+  const header = cardEl.createDiv({ cls: 'abkc-card-header' });
+  if (card.sourceKey) {
+    header.createEl('a', {
+      text: 'Apple Books',
+      href: card.sourceKey,
+      cls: 'abkc-card-brand abkc-card-brand-link',
+    });
+  } else {
+    header.createDiv({ text: 'Apple Books', cls: 'abkc-card-brand' });
+  }
+  header.createDiv({ text: 'Note Receipt', cls: 'abkc-card-title' });
+  cardEl.createDiv({ cls: 'abkc-card-rule' });
+  cardEl.createDiv({ text: `摘录 ${card.highlightIndex}`, cls: 'abkc-card-index' });
+
+  if (card.chapter) {
+    cardEl.createDiv({ text: card.chapter, cls: 'abkc-card-chapter' });
+  }
+
+  const highlightEl = cardEl.createDiv({ cls: 'abkc-card-highlight' });
+  renderInlineHighlight(highlightEl, card.highlight);
+
+  if (card.appleNote) {
+    const note = cardEl.createDiv({ cls: 'abkc-card-note' });
+    note.createDiv({ text: '想法', cls: 'abkc-card-label' });
+    note.createDiv({ text: card.appleNote });
+  }
+
+  cardEl.createDiv({ cls: 'abkc-card-rule' });
+  const meta = cardEl.createDiv({ cls: 'abkc-card-meta' });
+  meta.createDiv({ text: card.bookTitle });
+
+  const actions = cardEl.createDiv({ cls: 'abkc-card-actions' });
+  actions.createEl('button', { text: card.favorite ? '已收藏' : '收藏', cls: 'abkc-action-button' }).addEventListener('click', async () => {
+    await setHighlightFavorite(app, card, !card.favorite);
+    showNotice(!card.favorite ? '已收藏摘录' : '已取消收藏');
+    await context.onRefresh();
+  });
+  actions.createEl('button', { text: '编辑', cls: 'abkc-action-button' }).addEventListener('click', () => {
+    new EditNoteModal(app, card, async (note) => {
+      await setHighlightLocalNote(app, card, note);
+      showNotice('笔记已写回摘录文件');
+      await context.onRefresh();
+    }).open();
+  });
+  actions.createEl('button', { text: '复制', cls: 'abkc-action-button' }).addEventListener('click', async () => {
+    await navigator.clipboard.writeText(`> ${card.highlight}\n\n— ${card.bookTitle}`);
+  });
+  actions.createEl('button', { text: '打开', cls: 'abkc-action-button' }).addEventListener('click', async () => {
+    window.sessionStorage.setItem('abkc:last-card', card.annotationId);
+    await app.workspace.openLinkText(card.path, '', true);
+  });
+};
+
+export const renderCardsBoard = (
+  app: App,
+  container: HTMLElement,
+  cards: IHighlightCard[],
+  filters: BoardFilters = {},
+  context: RenderContext = { onRefresh: async () => {} },
+) => {
+  container.empty();
+  container.addClass('abkc-root');
+  container.toggleClass('abkc-mobile', Platform.isMobile);
+  container.toggleClass('abkc-phone', Platform.isPhone);
+  container.toggleClass('abkc-tablet', Platform.isTablet);
+  const title = container.createDiv({ cls: 'abkc-title' });
+  if (!filters.bookId) {
+    title.createEl('h2', { text: 'Apple Books 摘录' });
+  }
+  const titleMeta = title.createDiv({ cls: 'abkc-title-meta' });
+  if (context.initialOnlyWithAppleNote) {
+    titleMeta.createSpan({ text: '想法', cls: 'abkc-filter-chip' });
+  }
+  if (context.initialOnlyFavorite) {
+    titleMeta.createSpan({ text: '收藏', cls: 'abkc-filter-chip' });
+  }
+  if (context.initialOnlyWithChapter) {
+    titleMeta.createSpan({ text: '章节', cls: 'abkc-filter-chip' });
+  }
+  if (context.initialOnlyUnreviewed) {
+    titleMeta.createSpan({ text: '未整理', cls: 'abkc-filter-chip' });
+  }
+  const countEl = titleMeta.createSpan({ text: `${applyFilters(cards, filters).length} 张卡片`, cls: 'abkc-count' });
+
+  const toolbarHost = container.createDiv();
+  const board = container.createDiv({ cls: 'abkc-board' });
+  const render = (filteredCards: IHighlightCard[]) => {
+    board.empty();
+    countEl.setText(`${filteredCards.length} 张卡片`);
+
+    if (filteredCards.length === 0) {
+      board.createDiv({ text: '没有找到符合条件的摘录卡片。', cls: 'abkc-empty' });
+      return;
+    }
+
+    for (const card of filteredCards) {
+      renderCard(app, board, card, context);
+    }
+
+    const lastCardId = window.sessionStorage.getItem('abkc:last-card');
+    if (lastCardId) {
+      window.requestAnimationFrame(() => {
+        board.querySelector<HTMLElement>(`[data-annotation-id="${CSS.escape(lastCardId)}"]`)?.scrollIntoView({
+          block: 'center',
+          inline: 'nearest',
+        });
+      });
+    }
+  };
+
+  const initialBookTitle = getBookTitleFromFilter(cards, filters);
+  const initialState: ToolbarState = {
+    query: '',
+    bookTitle: initialBookTitle,
+    bookAuthor: '',
+    chapter: '',
+    color: '',
+    onlyFavorite: Boolean(context.initialOnlyFavorite),
+    onlyUnreviewed: Boolean(context.initialOnlyUnreviewed),
+    onlyWithAppleNote: Boolean(context.initialOnlyWithAppleNote),
+    onlyWithChapter: Boolean(context.initialOnlyWithChapter),
+  };
+
+  renderToolbar(toolbarHost, cards, render, filters, {
+    initialBookTitle,
+    initialOnlyFavorite: Boolean(context.initialOnlyFavorite),
+    initialOnlyUnreviewed: Boolean(context.initialOnlyUnreviewed),
+    initialOnlyWithAppleNote: Boolean(context.initialOnlyWithAppleNote),
+    initialOnlyWithChapter: Boolean(context.initialOnlyWithChapter),
+  });
+  render(applyToolbarState(applyFilters(cards, filters), initialState));
+  bindNoteToc(container);
+};

--- a/src/views/cardsView.ts
+++ b/src/views/cardsView.ts
@@ -1,0 +1,98 @@
+import { ItemView, WorkspaceLeaf } from 'obsidian';
+import type IBookHighlightsPlugin from '../../main';
+import { getHighlightCards } from '../modules/highlightRepository';
+import { renderCardsBoard } from './cardRenderer';
+
+export const CARDS_VIEW_TYPE = 'apple-books-knowledge-cards-view';
+
+export interface CardsViewState extends Record<string, unknown> {
+  onlyFavorite?: boolean;
+  onlyUnreviewed?: boolean;
+  onlyWithAppleNote?: boolean;
+  onlyWithChapter?: boolean;
+}
+
+export class CardsView extends ItemView {
+  private plugin: IBookHighlightsPlugin;
+  private state: CardsViewState = {};
+
+  constructor(leaf: WorkspaceLeaf, plugin: IBookHighlightsPlugin) {
+    super(leaf);
+    this.plugin = plugin;
+  }
+
+  getViewType(): string {
+    return CARDS_VIEW_TYPE;
+  }
+
+  getDisplayText(): string {
+    return 'Apple Books 摘录';
+  }
+
+  getIcon(): string {
+    return 'layout-dashboard';
+  }
+
+  async onOpen(): Promise<void> {
+    await this.render();
+  }
+
+  async render(): Promise<void> {
+    try {
+      const cards = await getHighlightCards(this.app, this.plugin.settings);
+      renderCardsBoard(
+        this.app,
+        this.contentEl,
+        cards,
+        {},
+        {
+          onRefresh: () => this.render(),
+          initialOnlyFavorite: Boolean(this.state.onlyFavorite),
+          initialOnlyUnreviewed: Boolean(this.state.onlyUnreviewed),
+          initialOnlyWithAppleNote: Boolean(this.state.onlyWithAppleNote),
+          initialOnlyWithChapter: Boolean(this.state.onlyWithChapter),
+        },
+      );
+    } catch (error) {
+      this.contentEl.empty();
+      this.contentEl.createDiv({
+        cls: 'abkc-empty',
+        text: `Apple Books 摘录卡片加载失败：${error instanceof Error ? error.message : String(error)}`,
+      });
+      console.error('[Apple Books Knowledge Cards]:', error);
+    }
+  }
+
+  getState(): Record<string, unknown> {
+    return this.state;
+  }
+
+  async setState(state: CardsViewState): Promise<void> {
+    this.state = state || {};
+    await this.render();
+  }
+}
+
+export const openCardsView = async (plugin: IBookHighlightsPlugin, state: CardsViewState = {}): Promise<void> => {
+  const existingLeaves = plugin.app.workspace.getLeavesOfType(CARDS_VIEW_TYPE);
+
+  if (existingLeaves.length > 0) {
+    await existingLeaves[0].setViewState({
+      type: CARDS_VIEW_TYPE,
+      state,
+      active: true,
+    });
+    plugin.app.workspace.revealLeaf(existingLeaves[0]);
+    return;
+  }
+
+  const leaf = plugin.app.workspace.getLeaf('tab');
+
+  await leaf.setViewState({
+    type: CARDS_VIEW_TYPE,
+    state,
+    active: true,
+  });
+
+  plugin.app.workspace.revealLeaf(leaf);
+};

--- a/src/views/dashboardView.ts
+++ b/src/views/dashboardView.ts
@@ -1,0 +1,263 @@
+import { type App, ItemView, Platform, WorkspaceLeaf } from 'obsidian';
+import type IBookHighlightsPlugin from '../../main';
+import type { IBookNoteSummary, IHighlightCard } from '../types';
+import { getBookSummaries, getHighlightCards } from '../modules/highlightRepository';
+import { openCardsView } from './cardsView';
+
+export const DASHBOARD_VIEW_TYPE = 'apple-books-knowledge-dashboard-view';
+
+interface LibraryStats {
+  bookCount: number;
+  highlightCount: number;
+  favoriteCount: number;
+  noteCount: number;
+}
+
+const getStats = (books: IBookNoteSummary[], cards: IHighlightCard[]): LibraryStats => {
+  return {
+    bookCount: books.length,
+    highlightCount: cards.length,
+    favoriteCount: cards.filter((card) => card.favorite).length,
+    noteCount: cards.filter((card) => card.appleNote.trim()).length,
+  };
+};
+
+const getRecentBooks = (books: IBookNoteSummary[]): IBookNoteSummary[] => {
+  return [...books].sort((a, b) => b.annotationCount - a.annotationCount).slice(0, 6);
+};
+
+const getRecentCards = (cards: IHighlightCard[]): IHighlightCard[] => {
+  return [...cards]
+    .sort((a, b) => {
+      const dateComparison = b.highlightCreationDate - a.highlightCreationDate;
+
+      if (dateComparison !== 0) {
+        return dateComparison;
+      }
+
+      return b.path.localeCompare(a.path);
+    })
+    .slice(0, 4);
+};
+
+const getRandomCards = (cards: IHighlightCard[], count = 4): IHighlightCard[] => {
+  return [...cards].sort(() => Math.random() - 0.5).slice(0, count);
+};
+
+const trimText = (value: string, maxLength: number): string => {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, maxLength)}…`;
+};
+
+const renderInlineHighlight = (container: HTMLElement, text: string): void => {
+  const lines = text.split('\n');
+
+  lines.forEach((line, index) => {
+    if (index > 0) {
+      container.createEl('br');
+    }
+
+    container.createSpan({ text: line, cls: 'abkc-highlight-text' });
+  });
+};
+
+const getCoverPath = (cover: string): string => {
+  return cover.match(/\[\[([^\]]+)\]\]/)?.[1] || '';
+};
+
+const openLibrary = async (app: App): Promise<void> => {
+  await app.workspace.openLinkText('我的图书馆.base', '', 'tab');
+};
+
+const renderStat = (container: HTMLElement, label: string, value: string | number, onClick: () => Promise<void>) => {
+  const stat = container.createEl('button', { cls: 'abkc-dashboard-stat' });
+  stat.createDiv({ text: String(value), cls: 'abkc-dashboard-stat-value' });
+  stat.createDiv({ text: label, cls: 'abkc-dashboard-stat-label' });
+  stat.addEventListener('click', async () => {
+    await onClick();
+  });
+};
+
+const renderBook = (app: App, container: HTMLElement, book: IBookNoteSummary) => {
+  const bookEl = container.createEl('button', { cls: 'abkc-dashboard-book' });
+  const coverPath = getCoverPath(book.cover);
+
+  if (coverPath) {
+    const image = bookEl.createEl('img', { attr: { alt: book.title } });
+    image.src = app.vault.adapter.getResourcePath(coverPath);
+  } else {
+    bookEl.createDiv({ text: book.title.slice(0, 1), cls: 'abkc-dashboard-cover-fallback' });
+  }
+
+  const meta = bookEl.createDiv({ cls: 'abkc-dashboard-book-meta' });
+  meta.createDiv({ text: book.title, cls: 'abkc-dashboard-book-title' });
+  meta.createDiv({ text: book.author, cls: 'abkc-dashboard-muted' });
+  meta.createDiv({ text: `${book.annotationCount} 条摘录 · ${book.status || '未标记'}`, cls: 'abkc-dashboard-muted' });
+
+  bookEl.addEventListener('click', async () => {
+    await app.workspace.openLinkText(book.path, '', false);
+  });
+};
+
+const renderHighlight = (app: App, container: HTMLElement, card: IHighlightCard) => {
+  const cardEl = container.createEl('button', { cls: `abkc-dashboard-highlight abkc-card abkc-card-${card.highlightColor}` });
+  const header = cardEl.createDiv({ cls: 'abkc-card-header' });
+  header.createDiv({ text: 'Apple Books', cls: 'abkc-card-brand' });
+  header.createDiv({ text: 'Note Receipt', cls: 'abkc-card-title' });
+  cardEl.createDiv({ cls: 'abkc-card-rule' });
+  cardEl.createDiv({ text: `摘录 ${card.highlightIndex}`, cls: 'abkc-card-index' });
+
+  if (card.chapter) {
+    cardEl.createDiv({ text: card.chapter, cls: 'abkc-card-chapter' });
+  }
+
+  const highlightEl = cardEl.createDiv({ cls: 'abkc-card-highlight' });
+  renderInlineHighlight(highlightEl, trimText(card.highlight, 160));
+
+  if (card.appleNote.trim()) {
+    const note = cardEl.createDiv({ cls: 'abkc-card-note' });
+    note.createDiv({ text: '想法', cls: 'abkc-card-label' });
+    note.createDiv({ text: trimText(card.appleNote, 90) });
+  }
+
+  cardEl.createDiv({ cls: 'abkc-card-rule' });
+  const meta = cardEl.createDiv({ cls: 'abkc-card-meta' });
+  meta.createDiv({ text: trimText(card.bookTitle, 42) });
+
+  cardEl.addEventListener('click', async () => {
+    await app.workspace.openLinkText(card.path, '', true);
+  });
+};
+
+const renderDashboardContent = async (
+  app: App,
+  plugin: IBookHighlightsPlugin,
+  contentEl: HTMLElement,
+  onRefresh: () => Promise<void>,
+): Promise<void> => {
+  contentEl.empty();
+  contentEl.addClass('abkc-dashboard-root');
+  contentEl.toggleClass('abkc-mobile', Platform.isMobile);
+
+  try {
+    const [books, cards] = await Promise.all([getBookSummaries(app, plugin.settings), getHighlightCards(app, plugin.settings)]);
+    const stats = getStats(books, cards);
+    const randomCards = getRandomCards(cards);
+
+    const hero = contentEl.createDiv({ cls: 'abkc-dashboard-hero' });
+    const heroText = hero.createDiv({ cls: 'abkc-dashboard-intro' });
+    heroText.createDiv({ text: 'Apple Books', cls: 'abkc-dashboard-kicker' });
+    heroText.createEl('h1', { text: '阅读仪表盘' });
+    heroText.createEl('p', { text: '从书、摘录、想法和随机回顾进入你的阅读现场。' });
+    const heroActions = heroText.createDiv({ cls: 'abkc-dashboard-actions' });
+    heroActions.createEl('button', { text: '打开摘录墙', cls: 'abkc-dashboard-primary' }).addEventListener('click', async () => {
+      await openCardsView(plugin);
+    });
+    heroActions.createEl('button', { text: '我的图书馆', cls: 'abkc-dashboard-secondary' }).addEventListener('click', async () => {
+      await app.workspace.openLinkText('我的图书馆.base', '', false);
+    });
+
+    const statGrid = hero.createDiv({ cls: 'abkc-dashboard-stats' });
+    renderStat(statGrid, '书籍', stats.bookCount, async () => {
+      await openLibrary(app);
+    });
+    renderStat(statGrid, '摘录', stats.highlightCount, async () => {
+      await openCardsView(plugin);
+    });
+    renderStat(statGrid, '想法', stats.noteCount, async () => {
+      await openCardsView(plugin, { onlyWithAppleNote: true });
+    });
+    renderStat(statGrid, '收藏', stats.favoriteCount, async () => {
+      await openCardsView(plugin, { onlyFavorite: true });
+    });
+
+    const mainGrid = contentEl.createDiv({ cls: 'abkc-dashboard-grid' });
+    const booksSection = mainGrid.createDiv({ cls: 'abkc-dashboard-section abkc-dashboard-section-wide' });
+    booksSection.createEl('h2', { text: '最近值得回看的书' });
+    const bookGrid = booksSection.createDiv({ cls: 'abkc-dashboard-books' });
+    for (const book of getRecentBooks(books)) {
+      renderBook(app, bookGrid, book);
+    }
+
+    const randomSection = mainGrid.createDiv({ cls: 'abkc-dashboard-section' });
+    const randomHeader = randomSection.createDiv({ cls: 'abkc-dashboard-section-header' });
+    randomHeader.createEl('h2', { text: '随机回顾' });
+    randomHeader.createEl('button', { text: '重新随机', cls: 'abkc-dashboard-section-action' }).addEventListener('click', async () => {
+      await onRefresh();
+    });
+    randomSection.createEl('p', { text: '从全部摘录里抽几张，适合每天快速复习。', cls: 'abkc-dashboard-muted' });
+    const randomList = randomSection.createDiv({ cls: 'abkc-dashboard-highlights' });
+    for (const card of randomCards) {
+      renderHighlight(app, randomList, card);
+    }
+
+    const recentSection = mainGrid.createDiv({ cls: 'abkc-dashboard-section' });
+    recentSection.createEl('h2', { text: '最近摘录' });
+    const recentList = recentSection.createDiv({ cls: 'abkc-dashboard-highlights' });
+    for (const card of getRecentCards(cards)) {
+      renderHighlight(app, recentList, card);
+    }
+  } catch (error) {
+    contentEl.createDiv({
+      cls: 'abkc-empty',
+      text: `Apple Books 阅读仪表盘加载失败：${error instanceof Error ? error.message : String(error)}`,
+    });
+    console.error('[Apple Books Knowledge Cards]:', error);
+  }
+};
+
+export class DashboardView extends ItemView {
+  private plugin: IBookHighlightsPlugin;
+
+  constructor(leaf: WorkspaceLeaf, plugin: IBookHighlightsPlugin) {
+    super(leaf);
+    this.plugin = plugin;
+  }
+
+  getViewType(): string {
+    return DASHBOARD_VIEW_TYPE;
+  }
+
+  getDisplayText(): string {
+    return 'Apple Books 阅读仪表盘';
+  }
+
+  getIcon(): string {
+    return 'book-open-check';
+  }
+
+  async onOpen(): Promise<void> {
+    await this.render();
+  }
+
+  async render(): Promise<void> {
+    await renderDashboardContent(this.app, this.plugin, this.contentEl, () => this.render());
+  }
+}
+
+export const renderDashboard = async (plugin: IBookHighlightsPlugin, container: HTMLElement): Promise<void> => {
+  await renderDashboardContent(plugin.app, plugin, container, () => renderDashboard(plugin, container));
+};
+
+export const openDashboardView = async (plugin: IBookHighlightsPlugin): Promise<void> => {
+  const existingLeaves = plugin.app.workspace.getLeavesOfType(DASHBOARD_VIEW_TYPE);
+
+  if (existingLeaves.length > 0) {
+    plugin.app.workspace.revealLeaf(existingLeaves[0]);
+    return;
+  }
+
+  const leaf = plugin.app.workspace.getLeaf(true);
+
+  await leaf.setViewState({
+    type: DASHBOARD_VIEW_TYPE,
+    active: true,
+  });
+
+  plugin.app.workspace.revealLeaf(leaf);
+};

--- a/styles.css
+++ b/styles.css
@@ -20,3 +20,1201 @@
 .modal-rewrite-all-books {
   color: var(--interactive-accent);
 }
+
+.abkc-root {
+  --abkc-paper: color-mix(in srgb, var(--background-primary) 94%, #f8f1df);
+  --abkc-paper-strong: color-mix(in srgb, var(--background-primary) 88%, #fff7e8);
+  --abkc-ink: var(--text-normal);
+  --abkc-muted: color-mix(in srgb, var(--text-muted) 84%, transparent);
+  --abkc-rule: color-mix(in srgb, var(--text-muted) 18%, transparent);
+  --abkc-surface-border: color-mix(in srgb, var(--text-muted) 15%, transparent);
+  container-type: inline-size;
+  box-sizing: border-box;
+  overflow: hidden;
+  padding: 16px 2px;
+  width: 100%;
+}
+
+.theme-dark .abkc-root {
+  --abkc-paper: color-mix(in srgb, var(--background-primary) 90%, #332b20);
+  --abkc-paper-strong: color-mix(in srgb, var(--background-primary) 82%, #403524);
+  --abkc-rule: color-mix(in srgb, var(--text-muted) 22%, transparent);
+  --abkc-surface-border: color-mix(in srgb, var(--text-muted) 20%, transparent);
+}
+
+.markdown-preview-view.wide-apple-book,
+.markdown-source-view.wide-apple-book,
+.wide-apple-book.markdown-preview-view,
+.wide-apple-book.markdown-source-view {
+  --file-line-width: min(1500px, calc(100vw - 120px));
+}
+
+.markdown-preview-view.wide-apple-book .markdown-preview-sizer,
+.markdown-source-view.wide-apple-book .cm-contentContainer,
+.wide-apple-book .markdown-preview-sizer,
+.wide-apple-book .cm-contentContainer {
+  max-width: var(--file-line-width) !important;
+}
+
+.markdown-preview-view.apple-books-dashboard-page .metadata-container,
+.markdown-reading-view .markdown-preview-view.apple-books-dashboard-page .metadata-container,
+.markdown-source-view.apple-books-dashboard-page .metadata-container,
+.markdown-source-view.apple-books-dashboard-page .metadata-properties,
+.markdown-source-view.apple-books-dashboard-page .cm-line:has(.cm-hmd-frontmatter),
+.markdown-source-view.apple-books-dashboard-page .inline-title,
+.markdown-preview-view.apple-books-dashboard-page h1:first-child,
+.markdown-reading-view .markdown-preview-view.apple-books-dashboard-page h1:first-child {
+  display: none !important;
+}
+
+.markdown-preview-view.apple-books-dashboard-page .markdown-preview-sizer,
+.markdown-source-view.apple-books-dashboard-page .cm-contentContainer {
+  max-width: none !important;
+  padding-top: 0 !important;
+}
+
+.markdown-preview-view.apple-books-dashboard-page,
+.markdown-source-view.apple-books-dashboard-page {
+  --file-line-width: min(1280px, calc(100vw - 96px));
+}
+
+.markdown-preview-view.apple-books-dashboard-page .markdown-preview-sizer {
+  margin-left: auto !important;
+  margin-right: auto !important;
+  max-width: var(--file-line-width) !important;
+}
+
+.is-mobile .markdown-preview-view.apple-books-dashboard-page,
+.is-mobile .markdown-source-view.apple-books-dashboard-page {
+  --file-line-width: calc(100vw - 16px);
+}
+
+.markdown-rendered.wide-apple-book .block-language-apple-books-board,
+.markdown-preview-view.wide-apple-book .block-language-apple-books-board {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: min(1500px, calc(100vw - 120px));
+}
+
+.abkc-note-toc-details {
+  margin: 14px 0 24px;
+}
+
+.abkc-note-toc-details summary {
+  background: color-mix(in srgb, var(--background-primary) 82%, var(--background-secondary));
+  border: 1px solid var(--abkc-surface-border);
+  border-radius: 999px;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1;
+  padding: 8px 12px;
+  user-select: none;
+}
+
+.abkc-note-toc-details summary:hover {
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+
+.abkc-note-toc {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 12px 0 0;
+}
+
+.abkc-note-toc a {
+  background: color-mix(in srgb, var(--background-primary) 82%, var(--background-secondary));
+  border: 1px solid var(--abkc-surface-border);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1;
+  padding: 7px 11px;
+  text-decoration: none;
+  transition:
+    background 0.16s ease,
+    border-color 0.16s ease,
+    color 0.16s ease,
+    transform 0.16s ease;
+}
+
+.abkc-note-toc a:hover {
+  background: var(--background-modifier-hover);
+  border-color: color-mix(in srgb, var(--interactive-accent) 30%, var(--abkc-surface-border));
+  color: var(--text-normal);
+  transform: translateY(-1px);
+}
+
+.abkc-card-focus {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 4px;
+  transition:
+    outline-color 0.2s ease,
+    outline-offset 0.2s ease;
+}
+
+.markdown-source-view .cm-html-embed:has(.abkc-root),
+.markdown-source-view .cm-html-embed.cm-embed-block:has(.abkc-root),
+.markdown-rendered .block-language-apple-books-board {
+  border: 0 !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+}
+
+.markdown-rendered .block-language-apple-books-board {
+  overflow: hidden;
+  width: 100%;
+}
+
+.markdown-rendered .block-language-apple-books-board .abkc-root {
+  max-width: none;
+}
+
+.markdown-source-view .cm-html-embed:has(.abkc-root) .edit-block-button {
+  display: none !important;
+}
+
+.abkc-title {
+  align-items: baseline;
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+}
+
+.abkc-title:has(h2) {
+  justify-content: space-between;
+}
+
+.abkc-title h2 {
+  margin: 0;
+}
+
+.abkc-count {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.abkc-title-meta {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.abkc-filter-chip {
+  background: color-mix(in srgb, var(--interactive-accent) 12%, var(--background-secondary));
+  border: 1px solid color-mix(in srgb, var(--interactive-accent) 22%, transparent);
+  border-radius: 999px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1;
+  padding: 5px 8px;
+}
+
+.abkc-toolbar {
+  align-items: center;
+  background: color-mix(in srgb, var(--background-primary) 78%, transparent);
+  border: 1px solid var(--abkc-surface-border);
+  border-radius: 24px;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.35) inset,
+    0 10px 30px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 20px;
+  min-width: 0;
+  padding: 10px;
+}
+
+.abkc-toolbar-group {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+}
+
+.abkc-toolbar-search-group,
+.abkc-toolbar-filters-group {
+  min-width: 0;
+}
+
+.abkc-toolbar-search-group {
+  flex: 1 1 260px;
+}
+
+.abkc-toolbar-filters-group {
+  flex: 999 1 520px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(128px, 1fr));
+}
+
+.abkc-toolbar-toggles-group,
+.abkc-toolbar-actions-group {
+  flex: 1 1 240px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.abkc-search {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: 100%;
+}
+
+.abkc-select,
+.abkc-button,
+.abkc-search {
+  appearance: none;
+  -webkit-appearance: none;
+  background: color-mix(in srgb, var(--background-primary) 90%, var(--background-secondary));
+  border: 1px solid var(--abkc-surface-border);
+  border-radius: 15px;
+  box-sizing: border-box;
+  color: var(--text-normal);
+  font: inherit;
+  font-size: 13px;
+  height: 38px;
+  line-height: 1.4;
+  padding: 8px 12px;
+}
+
+.abkc-select,
+.abkc-button {
+  flex: 1 1 auto;
+  min-height: 38px;
+  white-space: nowrap;
+}
+
+.abkc-toggle {
+  flex: 1 1 auto;
+}
+
+.abkc-select {
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--text-muted) 50%), linear-gradient(135deg, var(--text-muted) 50%, transparent 50%);
+  background-position:
+    calc(100% - 14px) 50%,
+    calc(100% - 9px) 50%;
+  background-repeat: no-repeat;
+  background-size:
+    5px 5px,
+    5px 5px;
+  max-width: none;
+  min-width: 0;
+  overflow: hidden;
+  padding-right: 26px;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.abkc-button {
+  cursor: pointer;
+  font-weight: 650;
+  transition:
+    background 0.16s ease,
+    border-color 0.16s ease,
+    box-shadow 0.16s ease,
+    transform 0.16s ease;
+}
+
+.abkc-button:hover {
+  background: var(--background-modifier-hover);
+  border-color: color-mix(in srgb, var(--interactive-accent) 28%, var(--abkc-surface-border));
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.06);
+  transform: translateY(-1px);
+}
+
+.abkc-toggle {
+  align-items: center;
+  background: color-mix(in srgb, var(--background-primary) 90%, var(--background-secondary));
+  border: 1px solid var(--abkc-surface-border);
+  border-radius: 15px;
+  box-sizing: border-box;
+  color: var(--text-muted);
+  display: inline-flex;
+  font-size: 13px;
+  gap: 6px;
+  height: 38px;
+  line-height: 1.4;
+  padding: 8px 12px;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.abkc-toggle input {
+  accent-color: var(--interactive-accent);
+  flex: 0 0 auto;
+  margin: 0;
+}
+
+.abkc-board {
+  column-gap: 18px;
+  column-width: 250px;
+  min-width: 0;
+  width: 100%;
+}
+
+.wide-apple-book .abkc-board {
+  column-width: 250px;
+}
+
+.abkc-card {
+  --abkc-accent: rgba(249, 213, 108, 0.84);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.28), transparent 46px), linear-gradient(var(--abkc-paper), var(--abkc-paper));
+  border: 1px solid var(--abkc-surface-border);
+  border-radius: 22px;
+  box-shadow:
+    0 1px 1px rgba(0, 0, 0, 0.04),
+    0 10px 28px rgba(0, 0, 0, 0.08);
+  box-sizing: border-box;
+  break-inside: avoid;
+  color: var(--abkc-ink);
+  display: block;
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', 'PingFang SC', sans-serif;
+  height: auto;
+  min-height: 188px;
+  min-width: 0;
+  overflow: visible;
+  padding: 16px 16px 14px;
+  position: relative;
+  width: 100%;
+  margin-bottom: 18px;
+  transition:
+    border-color 0.18s ease,
+    box-shadow 0.18s ease,
+    transform 0.18s ease;
+  -webkit-column-break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+.abkc-card:hover {
+  border-color: color-mix(in srgb, var(--abkc-accent) 54%, var(--abkc-surface-border));
+  box-shadow:
+    0 1px 1px rgba(0, 0, 0, 0.04),
+    0 16px 34px rgba(0, 0, 0, 0.12);
+  transform: translateY(-2px);
+}
+
+.abkc-card-yellow {
+  --abkc-accent: rgba(249, 213, 108, 0.9);
+}
+.abkc-card-green {
+  --abkc-accent: rgba(175, 213, 151, 0.9);
+}
+.abkc-card-blue {
+  --abkc-accent: rgba(181, 205, 238, 0.95);
+}
+.abkc-card-pink {
+  --abkc-accent: rgba(242, 178, 188, 0.92);
+}
+.abkc-card-purple {
+  --abkc-accent: rgba(214, 192, 238, 0.92);
+}
+.abkc-card-underline {
+  --abkc-accent: rgba(36, 33, 26, 0.45);
+}
+.theme-dark .abkc-card-yellow {
+  --abkc-accent: rgba(255, 214, 102, 0.78);
+}
+.theme-dark .abkc-card-green {
+  --abkc-accent: rgba(151, 206, 136, 0.74);
+}
+.theme-dark .abkc-card-blue {
+  --abkc-accent: rgba(134, 179, 232, 0.78);
+}
+.theme-dark .abkc-card-pink {
+  --abkc-accent: rgba(234, 137, 157, 0.76);
+}
+.theme-dark .abkc-card-purple {
+  --abkc-accent: rgba(190, 154, 230, 0.76);
+}
+.theme-dark .abkc-card-underline {
+  --abkc-accent: rgba(235, 229, 218, 0.42);
+}
+.abkc-card-yellow {
+  --abkc-highlight: rgba(249, 213, 108, 0.46);
+}
+.abkc-card-green {
+  --abkc-highlight: rgba(175, 213, 151, 0.44);
+}
+.abkc-card-blue {
+  --abkc-highlight: rgba(181, 205, 238, 0.5);
+}
+.abkc-card-pink {
+  --abkc-highlight: rgba(242, 178, 188, 0.48);
+}
+.abkc-card-purple {
+  --abkc-highlight: rgba(214, 192, 238, 0.48);
+}
+.theme-dark .abkc-card-yellow {
+  --abkc-highlight: rgba(255, 214, 102, 0.28);
+}
+.theme-dark .abkc-card-green {
+  --abkc-highlight: rgba(151, 206, 136, 0.25);
+}
+.theme-dark .abkc-card-blue {
+  --abkc-highlight: rgba(134, 179, 232, 0.28);
+}
+.theme-dark .abkc-card-pink {
+  --abkc-highlight: rgba(234, 137, 157, 0.26);
+}
+.theme-dark .abkc-card-purple {
+  --abkc-highlight: rgba(190, 154, 230, 0.26);
+}
+
+.abkc-card-yellow,
+.abkc-card-green,
+.abkc-card-blue,
+.abkc-card-pink,
+.abkc-card-purple {
+  --abkc-highlight-opacity: 0.62;
+}
+
+.abkc-card-header {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  text-align: left;
+}
+
+.abkc-card-brand {
+  color: var(--abkc-muted);
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  line-height: 1.2;
+  text-decoration: none;
+}
+
+.abkc-card-brand-link {
+  cursor: pointer;
+}
+
+.abkc-card-brand-link:hover {
+  color: var(--abkc-ink);
+  text-decoration: none;
+}
+
+.abkc-card-title {
+  color: var(--abkc-muted);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0;
+  margin-top: 0;
+}
+
+.abkc-card-rule {
+  border-top: 1px solid var(--abkc-rule);
+  margin: 10px 0 12px;
+}
+
+.abkc-card-index {
+  background: var(--abkc-accent);
+  border-radius: 999px;
+  color: var(--abkc-ink);
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  margin-bottom: 9px;
+  padding: 6px 10px;
+}
+
+.abkc-card-chapter {
+  color: var(--abkc-muted);
+  font-size: 13px;
+  line-height: 1.55;
+  margin-bottom: 10px;
+}
+
+.abkc-card-highlight {
+  color: var(--abkc-ink);
+  display: block;
+  font-size: 14.5px;
+  font-weight: 450;
+  letter-spacing: -0.01em;
+  line-height: 1.68;
+  max-height: none;
+  overflow: visible;
+  white-space: pre-wrap;
+}
+
+.abkc-card:not(.abkc-card-underline) .abkc-highlight-text {
+  background: var(--abkc-highlight, rgba(249, 213, 108, 0.46));
+  border-radius: 0.46em;
+  box-decoration-break: clone;
+  line-height: 1.7;
+  margin: 0 -0.02em;
+  padding: 0.08em 0.18em;
+  -webkit-box-decoration-break: clone;
+}
+
+.abkc-card-underline .abkc-highlight-text {
+  text-decoration-line: underline;
+  text-decoration-thickness: 0.12em;
+  text-decoration-color: var(--abkc-accent);
+  text-underline-offset: 0.18em;
+}
+
+.abkc-card-note {
+  background: color-mix(in srgb, var(--abkc-accent) 15%, var(--abkc-paper-strong));
+  border: 1px solid color-mix(in srgb, var(--abkc-accent) 28%, transparent);
+  border-radius: 15px;
+  color: var(--abkc-ink);
+  display: block;
+  height: auto;
+  font-size: 13px;
+  line-height: 1.62;
+  margin-top: 12px;
+  max-height: none;
+  overflow: visible;
+  padding: 10px 11px;
+  white-space: pre-wrap;
+}
+
+.abkc-card-label,
+.abkc-card-meta {
+  color: var(--abkc-muted);
+  font-size: 11.5px;
+}
+
+.abkc-card-label {
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.abkc-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.abkc-action-button,
+.abkc-action-link {
+  align-items: center;
+  background: color-mix(in srgb, var(--background-primary) 76%, transparent);
+  border: 1px solid color-mix(in srgb, var(--text-muted) 14%, transparent);
+  border-radius: 999px;
+  box-sizing: border-box;
+  color: var(--abkc-muted);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 550;
+  justify-content: center;
+  line-height: 1.2;
+  min-height: 28px;
+  padding: 5px 9px;
+  text-decoration: none;
+  vertical-align: middle;
+  transition:
+    background 0.16s ease,
+    border-color 0.16s ease,
+    color 0.16s ease,
+    transform 0.16s ease;
+}
+
+.abkc-action-button:hover,
+.abkc-action-link:hover {
+  background: color-mix(in srgb, var(--abkc-accent) 18%, var(--background-primary));
+  border-color: color-mix(in srgb, var(--abkc-accent) 36%, transparent);
+  color: var(--abkc-ink);
+  transform: translateY(-1px);
+}
+
+.abkc-empty {
+  color: var(--text-muted);
+}
+
+.abkc-modal-muted {
+  color: var(--text-muted);
+}
+
+.abkc-note-editor {
+  box-sizing: border-box;
+  min-height: 220px;
+  resize: vertical;
+  width: 100%;
+}
+
+.abkc-dashboard-root {
+  --abkc-dashboard-border: color-mix(in srgb, var(--text-muted) 10%, transparent);
+  --abkc-dashboard-hairline: color-mix(in srgb, var(--text-muted) 8%, transparent);
+  --abkc-dashboard-surface: color-mix(in srgb, var(--background-primary) 97%, var(--background-secondary));
+  --abkc-dashboard-soft: color-mix(in srgb, var(--background-primary) 92%, var(--background-secondary));
+  box-sizing: border-box;
+  color: var(--text-normal);
+  container-type: inline-size;
+  min-height: 100%;
+  overflow: auto;
+  padding: 22px;
+}
+
+.abkc-dashboard-hero {
+  align-items: stretch;
+  background:
+    radial-gradient(circle at 0% 0%, color-mix(in srgb, var(--interactive-accent) 8%, transparent), transparent 32%),
+    linear-gradient(180deg, color-mix(in srgb, var(--background-primary) 98%, transparent), var(--abkc-dashboard-surface));
+  border: 1px solid var(--abkc-dashboard-border);
+  border-radius: 28px;
+  box-shadow:
+    0 1px 1px rgba(0, 0, 0, 0.025),
+    0 12px 34px rgba(0, 0, 0, 0.045);
+  display: grid;
+  gap: 28px;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.88fr);
+  margin-bottom: 18px;
+  padding: 26px;
+}
+
+.abkc-dashboard-intro {
+  align-self: center;
+  min-width: 0;
+}
+
+.abkc-dashboard-kicker {
+  color: color-mix(in srgb, var(--text-muted) 88%, var(--interactive-accent));
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.abkc-dashboard-hero h1 {
+  font-size: clamp(32px, 5.4cqi, 54px);
+  font-weight: 780;
+  letter-spacing: -0.06em;
+  line-height: 0.98;
+  margin: 10px 0 12px;
+}
+
+.abkc-dashboard-hero p {
+  color: var(--text-muted);
+  font-size: 15px;
+  line-height: 1.58;
+  margin: 0;
+  max-width: 500px;
+}
+
+.abkc-dashboard-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.abkc-dashboard-primary,
+.abkc-dashboard-secondary {
+  appearance: none;
+  -webkit-appearance: none;
+  border-radius: 999px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.2;
+  min-height: 34px;
+  outline: none;
+  padding: 7px 13px;
+  transition:
+    background 0.16s ease,
+    border-color 0.16s ease,
+    box-shadow 0.16s ease,
+    transform 0.16s ease;
+}
+
+.abkc-dashboard-primary {
+  background: color-mix(in srgb, var(--interactive-accent) 12%, var(--background-primary));
+  border: 1px solid color-mix(in srgb, var(--interactive-accent) 20%, var(--abkc-dashboard-border));
+  color: var(--text-normal);
+}
+
+.abkc-dashboard-secondary {
+  background: color-mix(in srgb, var(--background-primary) 72%, transparent);
+  border: 1px solid var(--abkc-dashboard-border);
+  color: var(--text-normal);
+}
+
+.abkc-dashboard-primary:hover,
+.abkc-dashboard-secondary:hover {
+  background: color-mix(in srgb, var(--interactive-accent) 13%, var(--background-primary));
+  border-color: color-mix(in srgb, var(--interactive-accent) 30%, var(--abkc-dashboard-border));
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.055);
+  transform: translateY(-1px);
+}
+
+.abkc-dashboard-stats {
+  align-content: stretch;
+  display: grid;
+  gap: 10px 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.abkc-dashboard-stat {
+  align-items: flex-start;
+  appearance: none;
+  -webkit-appearance: none;
+  background: color-mix(in srgb, var(--background-primary) 86%, transparent);
+  border: 1px solid var(--abkc-dashboard-border);
+  border-radius: 20px;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.36) inset,
+    0 8px 18px rgba(0, 0, 0, 0.035);
+  box-sizing: border-box;
+  color: var(--text-normal);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  font: inherit;
+  justify-content: center;
+  min-height: 86px;
+  padding: 15px 16px 14px;
+  position: relative;
+  text-align: left;
+  transition:
+    background 0.16s ease,
+    border-color 0.16s ease,
+    box-shadow 0.16s ease,
+    transform 0.16s ease;
+  width: 100%;
+}
+
+.abkc-dashboard-stat:hover {
+  background: color-mix(in srgb, var(--interactive-accent) 7%, var(--background-primary));
+  border-color: color-mix(in srgb, var(--interactive-accent) 24%, var(--abkc-dashboard-border));
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.42) inset,
+    0 12px 24px rgba(0, 0, 0, 0.06);
+  transform: translateY(-1px);
+}
+
+.abkc-dashboard-stat-value {
+  color: var(--text-normal);
+  display: block;
+  font-size: clamp(28px, 4.2cqi, 42px);
+  font-weight: 800;
+  letter-spacing: -0.06em;
+  line-height: 1;
+  margin: 0 0 8px;
+  max-width: 100%;
+}
+
+.abkc-dashboard-stat-label,
+.abkc-dashboard-muted {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.abkc-dashboard-stat-label {
+  color: var(--text-muted);
+  display: block;
+  font-size: 12.5px;
+  font-weight: 560;
+  letter-spacing: 0;
+  margin: 0;
+}
+
+.abkc-dashboard-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 0.78fr);
+}
+
+.abkc-dashboard-section {
+  background: var(--abkc-dashboard-surface);
+  border: 1px solid var(--abkc-dashboard-border);
+  border-radius: 24px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.035);
+  min-width: 0;
+  padding: 16px;
+}
+
+.abkc-dashboard-section-header {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.abkc-dashboard-section-wide {
+  grid-column: 1 / -1;
+}
+
+.abkc-dashboard-section h2 {
+  font-size: 18px;
+  letter-spacing: -0.02em;
+  margin: 0 0 14px;
+}
+
+.abkc-dashboard-section-header h2 {
+  margin: 0;
+}
+
+.abkc-dashboard-section-action {
+  appearance: none;
+  -webkit-appearance: none;
+  background: color-mix(in srgb, var(--background-primary) 78%, transparent);
+  border: 1px solid var(--abkc-dashboard-border);
+  border-radius: 999px;
+  color: var(--text-normal);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 650;
+  min-height: 32px;
+  padding: 6px 12px;
+  transition:
+    background 0.16s ease,
+    border-color 0.16s ease,
+    transform 0.16s ease;
+}
+
+.abkc-dashboard-section-action:hover {
+  background: var(--background-modifier-hover);
+  border-color: color-mix(in srgb, var(--interactive-accent) 28%, var(--abkc-dashboard-border));
+  transform: translateY(-1px);
+}
+
+.abkc-dashboard-books {
+  align-items: stretch;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.abkc-dashboard-root button.abkc-dashboard-book,
+.abkc-dashboard-root button.abkc-dashboard-highlight {
+  appearance: none;
+  -webkit-appearance: none;
+  background: color-mix(in srgb, var(--background-primary) 74%, transparent);
+  border: 1px solid var(--abkc-dashboard-border);
+  border-radius: 20px;
+  box-sizing: border-box;
+  color: var(--text-normal);
+  cursor: pointer;
+  font: inherit;
+  height: auto;
+  line-height: normal;
+  margin: 0;
+  max-width: none;
+  min-width: 0;
+  overflow: visible;
+  text-align: left;
+  transition:
+    border-color 0.16s ease,
+    box-shadow 0.16s ease,
+    transform 0.16s ease;
+  white-space: normal;
+  width: 100%;
+}
+
+.abkc-dashboard-root button.abkc-dashboard-book:hover,
+.abkc-dashboard-root button.abkc-dashboard-highlight:hover {
+  border-color: color-mix(in srgb, var(--interactive-accent) 32%, var(--abkc-dashboard-border));
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.08);
+  transform: translateY(-1px);
+}
+
+.abkc-dashboard-root button.abkc-dashboard-book {
+  align-items: center;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 68px minmax(0, 1fr);
+  min-height: 112px;
+  padding: 12px;
+}
+
+.abkc-dashboard-book img,
+.abkc-dashboard-cover-fallback {
+  aspect-ratio: 3 / 4;
+  border-radius: 12px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+  display: block;
+  height: auto;
+  object-fit: cover;
+  width: 68px;
+}
+
+.abkc-dashboard-cover-fallback {
+  align-items: center;
+  background: color-mix(in srgb, var(--interactive-accent) 18%, var(--background-secondary));
+  color: var(--text-muted);
+  display: flex;
+  font-size: 22px;
+  font-weight: 800;
+  justify-content: center;
+}
+
+.abkc-dashboard-book-meta {
+  min-width: 0;
+}
+
+.abkc-dashboard-book-title {
+  font-size: 14px;
+  font-weight: 720;
+  line-height: 1.35;
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.abkc-dashboard-highlights {
+  display: grid;
+  gap: 14px;
+}
+
+.abkc-dashboard-root button.abkc-dashboard-highlight {
+  cursor: pointer;
+  display: block;
+  margin-bottom: 0;
+  min-height: 0;
+}
+
+.abkc-dashboard-root.abkc-mobile {
+  margin-left: calc(-1 * var(--size-4-2, 8px));
+  margin-right: calc(-1 * var(--size-4-2, 8px));
+  padding: 8px;
+  width: calc(100% + (var(--size-4-2, 8px) * 2));
+}
+
+.abkc-dashboard-root.abkc-mobile .abkc-dashboard-hero,
+.abkc-dashboard-root.abkc-mobile .abkc-dashboard-grid {
+  grid-template-columns: 1fr;
+}
+
+.abkc-dashboard-root.abkc-mobile .abkc-dashboard-hero {
+  border-radius: 22px;
+  gap: 18px;
+  padding: 18px;
+}
+
+.abkc-dashboard-root.abkc-mobile .abkc-dashboard-stats {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.abkc-dashboard-root.abkc-mobile .abkc-dashboard-stat {
+  min-height: 72px;
+  padding: 12px;
+}
+
+.abkc-dashboard-root.abkc-mobile .abkc-dashboard-stat-value {
+  font-size: 28px;
+}
+
+@container (max-width: 920px) {
+  .abkc-dashboard-hero,
+  .abkc-dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .abkc-dashboard-books {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+}
+
+@container (max-width: 520px) {
+  .abkc-dashboard-root {
+    padding: 8px;
+  }
+
+  .abkc-dashboard-books {
+    grid-template-columns: 1fr;
+  }
+
+  .abkc-dashboard-root button.abkc-dashboard-book {
+    grid-template-columns: 60px minmax(0, 1fr);
+    min-height: 100px;
+  }
+
+  .abkc-dashboard-book img,
+  .abkc-dashboard-cover-fallback {
+    width: 60px;
+  }
+}
+
+@container (max-width: 760px) {
+  .abkc-root {
+    padding: 10px 0;
+  }
+
+  .abkc-toolbar {
+    border-radius: 22px;
+    padding: 9px;
+  }
+
+  .abkc-toolbar-filters-group {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .abkc-toolbar-toggles-group,
+  .abkc-toolbar-actions-group {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .abkc-board {
+    column-count: 1;
+    column-width: auto;
+  }
+
+  .abkc-card {
+    min-height: auto;
+    padding: 16px 15px 14px;
+  }
+}
+
+.abkc-root.abkc-mobile {
+  box-sizing: border-box;
+  padding: 8px;
+}
+
+.abkc-root.abkc-mobile .abkc-toolbar {
+  display: flex;
+  gap: 9px;
+}
+
+.abkc-root.abkc-mobile .abkc-toolbar-group {
+  width: 100%;
+}
+
+.abkc-root.abkc-mobile .abkc-toolbar-filters-group {
+  flex-basis: 100%;
+}
+
+.abkc-root.abkc-mobile .abkc-search,
+.abkc-root.abkc-mobile .abkc-select,
+.abkc-root.abkc-mobile .abkc-button,
+.abkc-root.abkc-mobile .abkc-toggle {
+  box-sizing: border-box;
+  max-width: none;
+  width: 100%;
+}
+
+.abkc-root.abkc-mobile .abkc-search,
+.abkc-root.abkc-mobile .abkc-select,
+.abkc-root.abkc-mobile .abkc-button,
+.abkc-root.abkc-mobile .abkc-toggle {
+  font-size: 14px;
+  height: 42px;
+  min-height: 42px;
+}
+
+.abkc-root.abkc-tablet .abkc-toolbar {
+  align-items: center;
+}
+
+.abkc-root.abkc-tablet .abkc-toolbar-toggles-group,
+.abkc-root.abkc-tablet .abkc-toolbar-actions-group {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.abkc-root.abkc-phone .abkc-toolbar {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 0 2px;
+}
+
+.abkc-root.abkc-phone .abkc-toolbar-filters-group {
+  grid-template-columns: 1fr;
+}
+
+.abkc-root.abkc-phone .abkc-toolbar-toggles-group,
+.abkc-root.abkc-phone .abkc-toolbar-actions-group {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.abkc-root.abkc-phone .abkc-toggle {
+  justify-content: center;
+}
+
+.abkc-root.abkc-phone .abkc-board {
+  column-count: initial;
+  column-gap: 0;
+  column-width: initial;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr);
+  margin-left: auto;
+  margin-right: auto;
+  max-width: calc(100vw - 34px);
+  width: 100%;
+}
+
+.abkc-root.abkc-phone .abkc-card {
+  break-inside: auto;
+  box-sizing: border-box;
+  margin-bottom: 0;
+  max-width: 100%;
+  min-height: auto;
+  padding: 15px 14px 13px;
+  width: 100%;
+  -webkit-column-break-inside: auto;
+}
+
+.abkc-root.abkc-phone .abkc-card-highlight,
+.abkc-root.abkc-phone .abkc-card-note {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.abkc-root.abkc-tablet .abkc-board {
+  column-gap: 18px;
+  column-width: 250px;
+  display: block;
+}
+
+.abkc-root.abkc-tablet .abkc-card {
+  break-inside: avoid;
+  margin-bottom: 18px;
+  -webkit-column-break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+.abkc-root.abkc-mobile .abkc-card:hover {
+  transform: none;
+}
+
+.abkc-root.abkc-mobile .abkc-card-highlight {
+  font-size: 15px;
+  line-height: 1.72;
+}
+
+.abkc-root.abkc-mobile .abkc-card-actions {
+  display: grid;
+  gap: 6px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.abkc-root.abkc-mobile .abkc-action-button {
+  font-size: 12px;
+  min-width: 0;
+  padding-left: 4px;
+  padding-right: 4px;
+  width: 100%;
+}
+
+@container (min-width: 1320px) {
+  .abkc-board {
+    column-gap: 18px;
+    column-width: 250px;
+  }
+}

--- a/test/fixtures/annotationProcessing/aggregatedBooksAndAnnotations.json
+++ b/test/fixtures/annotationProcessing/aggregatedBooksAndAnnotations.json
@@ -20,7 +20,8 @@
         "highlightModificationDate": 685151385.91602,
         "highlightStyle": 3
       }
-    ]
+    ],
+    "bookPath": ""
   },
   {
     "bookId": "THBFYNJKTGFTTVCGSAE2",
@@ -43,7 +44,8 @@
         "highlightModificationDate": 685151385.91602,
         "highlightStyle": 3
       }
-    ]
+    ],
+    "bookPath": ""
   },
   {
     "bookId": "THBFYNJKTGFTTVCGSAE3",
@@ -77,7 +79,8 @@
         "highlightModificationDate": 685151385.91602,
         "highlightStyle": 2
       }
-    ]
+    ],
+    "bookPath": ""
   },
   {
     "bookId": "THBFYNJKTGFTTVCGSAE6",
@@ -133,6 +136,7 @@
         "highlightModificationDate": 743629954.550869,
         "highlightStyle": 3
       }
-    ]
+    ],
+    "bookPath": ""
   }
 ]

--- a/test/fixtures/dataFetching/allBooksInDatabase.json
+++ b/test/fixtures/dataFetching/allBooksInDatabase.json
@@ -7,7 +7,8 @@
     "bookLanguage": "EN",
     "bookLastOpenedDate": 726602576.413094,
     "bookFinishedDate": 726602576.413094,
-    "bookCoverUrl": ""
+    "bookCoverUrl": "",
+    "bookPath": ""
   },
   {
     "bookId": "THBFYNJKTGFTTVCGSAE2",
@@ -17,7 +18,8 @@
     "bookLanguage": "EN",
     "bookLastOpenedDate": 726602576.413094,
     "bookFinishedDate": 726602576.413094,
-    "bookCoverUrl": ""
+    "bookCoverUrl": "",
+    "bookPath": ""
   },
   {
     "bookId": "THBFYNJKTGFTTVCGSAE3",
@@ -27,7 +29,8 @@
     "bookLanguage": "EN",
     "bookLastOpenedDate": 726602576.413094,
     "bookFinishedDate": 726602576.413094,
-    "bookCoverUrl": ""
+    "bookCoverUrl": "",
+    "bookPath": ""
   },
   {
     "bookId": "THBFYNJKTGFTTVCGSAE4",
@@ -38,7 +41,8 @@
     "bookLastOpenedDate": 726602576.413094,
     "bookFinishedDate": 726602576.413094,
     "bookCoverUrl": "",
-    "ZPURCHASEDATE": null
+    "ZPURCHASEDATE": null,
+    "bookPath": ""
   },
   {
     "bookId": "THBFYNJKTGFTTVCGSAE5",
@@ -48,7 +52,8 @@
     "bookLanguage": "EN",
     "bookLastOpenedDate": 726602576.413094,
     "bookFinishedDate": 726602576.413094,
-    "bookCoverUrl": ""
+    "bookCoverUrl": "",
+    "bookPath": ""
   },
   {
     "bookId": "THBFYNJKTGFTTVCGSAE6",
@@ -58,6 +63,7 @@
     "bookLanguage": "EN",
     "bookLastOpenedDate": 726602576.413094,
     "bookFinishedDate": 726602576.413094,
-    "bookCoverUrl": ""
+    "bookCoverUrl": "",
+    "bookPath": ""
   }
 ]

--- a/test/fixtures/dataFetching/purchasedBooks.json
+++ b/test/fixtures/dataFetching/purchasedBooks.json
@@ -7,7 +7,8 @@
     "bookLanguage": "EN",
     "bookLastOpenedDate": 726602576.413094,
     "bookFinishedDate": 726602576.413094,
-    "bookCoverUrl": ""
+    "bookCoverUrl": "",
+    "bookPath": ""
   },
   {
     "bookId": "THBFYNJKTGFTTVCGSAE2",
@@ -17,7 +18,8 @@
     "bookLanguage": "EN",
     "bookLastOpenedDate": 726602576.413094,
     "bookFinishedDate": 726602576.413094,
-    "bookCoverUrl": ""
+    "bookCoverUrl": "",
+    "bookPath": ""
   },
   {
     "bookId": "THBFYNJKTGFTTVCGSAE3",
@@ -27,7 +29,8 @@
     "bookLanguage": "EN",
     "bookLastOpenedDate": 726602576.413094,
     "bookFinishedDate": 726602576.413094,
-    "bookCoverUrl": ""
+    "bookCoverUrl": "",
+    "bookPath": ""
   },
   {
     "bookId": "THBFYNJKTGFTTVCGSAE5",
@@ -37,7 +40,8 @@
     "bookLanguage": "EN",
     "bookLastOpenedDate": 726602576.413094,
     "bookFinishedDate": 726602576.413094,
-    "bookCoverUrl": ""
+    "bookCoverUrl": "",
+    "bookPath": ""
   },
   {
     "bookId": "THBFYNJKTGFTTVCGSAE6",
@@ -47,6 +51,7 @@
     "bookLanguage": "EN",
     "bookLastOpenedDate": 726602576.413094,
     "bookFinishedDate": 726602576.413094,
-    "bookCoverUrl": ""
+    "bookCoverUrl": "",
+    "bookPath": ""
   }
 ]

--- a/test/integration/importHighlights.spec.ts
+++ b/test/integration/importHighlights.spec.ts
@@ -1,6 +1,4 @@
-import fs from 'fs';
 import { App, TFile, TFolder } from 'obsidian';
-import path from 'path';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import type { IBookHighlightsPluginSettings } from '../../src/types';
 import { importHighlights } from '../../src/importHighlights';
@@ -36,6 +34,16 @@ describe('importHighlights', () => {
     keepMeSectionData: {},
   };
 
+  const expectBookContent = (content: string, bookTitle: string, bookId: string) => {
+    expect(content).toContain('type: book');
+    expect(content).toContain(`title: "${bookTitle}"`);
+    expect(content).toContain(`book_id: "${bookId}"`);
+    expect(content).toContain('<summary>摘录目录</summary>');
+    expect(content).toContain('## 本书摘录');
+    expect(content).toContain('```apple-books-board');
+    expect(content).toContain(`book_id: ${bookId}`);
+  };
+
   afterEach(() => {
     vi.resetAllMocks();
   });
@@ -46,18 +54,17 @@ describe('importHighlights', () => {
     vi.spyOn(annotationProcessing, 'aggregateBooksWithAnnotations').mockResolvedValue(aggregatedBooksAndAnnotations);
 
     const createBookFileSpy = vi.spyOn(vaultManagement, 'createBookFile');
-    const renderedBookOne = fs.readFileSync(path.join(process.cwd(), 'test', 'fixtures', 'templateProcessing', 'renderedAnnotationsOne-default.md'), 'utf-8'); // oxfmt-ignore
-    const renderedBookTwo = fs.readFileSync(path.join(process.cwd(), 'test', 'fixtures', 'templateProcessing', 'renderedAnnotationsTwo-default.md'), 'utf-8'); // oxfmt-ignore
-    const renderedBookThree = fs.readFileSync(path.join(process.cwd(), 'test', 'fixtures', 'templateProcessing', 'renderedAnnotationsThree-default.md'), 'utf-8'); // oxfmt-ignore
-    const renderedBookFour = fs.readFileSync(path.join(process.cwd(), 'test', 'fixtures', 'templateProcessing', 'renderedAnnotationsFour-default.md'), 'utf-8'); // oxfmt-ignore
+    const upsertFileSpy = vi.spyOn(vaultManagement, 'upsertFile');
 
     await importHighlights(vaultManagement, mockSettings);
 
     expect(createBookFileSpy).toHaveBeenCalledTimes(4);
-    expect(createBookFileSpy).toHaveBeenNthCalledWith(1, 'iPhone User Guide', renderedBookOne);
-    expect(createBookFileSpy).toHaveBeenNthCalledWith(2, 'iPad User Guide', renderedBookTwo);
-    expect(createBookFileSpy).toHaveBeenNthCalledWith(3, 'Mac User Guide', renderedBookThree);
-    expect(createBookFileSpy).toHaveBeenNthCalledWith(4, 'A book to test sorting feature', renderedBookFour);
+    expect(createBookFileSpy).toHaveBeenNthCalledWith(1, 'iPhone User Guide', expect.any(String));
+    expectBookContent(createBookFileSpy.mock.calls[0][1], 'iPhone User Guide', 'THBFYNJKTGFTTVCGSAE1');
+    expect(upsertFileSpy).toHaveBeenCalledWith(
+      'ibooks-highlights/cards/iPhone User Guide/摘录-001.md',
+      expect.stringContaining('# 摘录 1'),
+    );
   });
 
   test('Should modify existing files when importMode === modify', async () => {
@@ -67,11 +74,11 @@ describe('importHighlights', () => {
     vi.spyOn(vaultManagement, 'getFilePath').mockReturnValue({ path: 'ibooks-highlights/iPhone User Guide.md' } as TFile);
 
     const modifyBookFileSpy = vi.spyOn(vaultManagement, 'modifyBookFile');
-    const renderedBookOne = fs.readFileSync(path.join(process.cwd(), 'test', 'fixtures', 'templateProcessing', 'renderedAnnotationsOne-default.md'), 'utf-8'); // oxfmt-ignore
 
     await importHighlights(vaultManagement, mockSettings, 'modify');
 
-    expect(modifyBookFileSpy).toHaveBeenCalledWith({ path: 'ibooks-highlights/iPhone User Guide.md' }, renderedBookOne);
+    expect(modifyBookFileSpy).toHaveBeenCalledWith({ path: 'ibooks-highlights/iPhone User Guide.md' }, expect.any(String));
+    expectBookContent(modifyBookFileSpy.mock.calls[0][1], 'iPhone User Guide', 'THBFYNJKTGFTTVCGSAE1');
   });
 
   test('Should create a new file if importMode === modify but the file does not exist', async () => {
@@ -81,18 +88,17 @@ describe('importHighlights', () => {
     vi.spyOn(vaultManagement, 'getFilePath').mockReturnValue(null);
 
     const createBookFileSpy = vi.spyOn(vaultManagement, 'createBookFile');
-    const renderedBookOne = fs.readFileSync(path.join(process.cwd(), 'test', 'fixtures', 'templateProcessing', 'renderedAnnotationsOne-default.md'), 'utf-8'); // oxfmt-ignore
 
     await importHighlights(vaultManagement, mockSettings, 'modify');
 
-    expect(createBookFileSpy).toHaveBeenCalledWith('iPhone User Guide', renderedBookOne);
+    expect(createBookFileSpy).toHaveBeenCalledWith('iPhone User Guide', expect.any(String));
+    expectBookContent(createBookFileSpy.mock.calls[0][1], 'iPhone User Guide', 'THBFYNJKTGFTTVCGSAE1');
   });
 
   test('Should embed Keep Me section data if it is stored in settings', async () => {
-    const defaultTemplateWithKeepMeSectionDelimiters = fs.readFileSync(path.join(process.cwd(), 'test', 'fixtures', 'templateProcessing', 'defaultTemplateWithKeepMeSectionDelimiters.md'), 'utf-8'); // oxfmt-ignore
     const settingsWithKeepMeSection: IBookHighlightsPluginSettings = {
       ...mockSettings,
-      template: defaultTemplateWithKeepMeSectionDelimiters,
+      template: `${defaultTemplate}\n%% keep-me %%\n%% /keep-me %%\n`,
       keepMeSectionData: {
         'iPhone User Guide': `This is a great guide!📕 I learned so much from it.\nDefinitely need to recommend it to Aaron. 😎🤜🤛😎`,
       },
@@ -102,11 +108,13 @@ describe('importHighlights', () => {
     vi.spyOn(annotationProcessing, 'aggregateBooksWithAnnotations').mockResolvedValue([aggregatedBooksAndAnnotations[0]]);
 
     const createBookFileSpy = vi.spyOn(vaultManagement, 'createBookFile');
-    const renderedBookOneWithKeepMeSection = fs.readFileSync(path.join(process.cwd(), 'test', 'fixtures', 'manageKeepMeSection', 'bookOneWithKeepMeSection.md'), 'utf-8'); // oxfmt-ignore
 
     await importHighlights(vaultManagement, settingsWithKeepMeSection);
 
-    expect(createBookFileSpy).toHaveBeenCalledWith('iPhone User Guide', renderedBookOneWithKeepMeSection);
+    expect(createBookFileSpy).toHaveBeenCalledWith(
+      'iPhone User Guide',
+      expect.stringContaining('Definitely need to recommend it to Aaron.'),
+    );
   });
 
   test('Should throw aggregated error if any file operation fails', async () => {
@@ -114,7 +122,7 @@ describe('importHighlights', () => {
     vi.spyOn(annotationProcessing, 'aggregateBooksWithAnnotations').mockResolvedValue([aggregatedBooksAndAnnotations[0]]);
     vi.spyOn(vaultManagement, 'createBookFile').mockRejectedValueOnce(new Error('File write failed'));
 
-    await expect(importHighlights(vaultManagement, mockSettings)).rejects.toThrow(/file operation\(s\) failed during import/);
+    await expect(importHighlights(vaultManagement, mockSettings)).rejects.toThrow(/导入《iPhone User Guide》失败：File write failed/);
   });
 
   test('Should not create highlights folder if it already exists', async () => {

--- a/test/integration/main.spec.ts
+++ b/test/integration/main.spec.ts
@@ -41,7 +41,7 @@ describe('quick-preview event', () => {
   });
 
   test('Should call saveKeepMeSectionData and update keepMeSectionData in settings', async () => {
-    const file = { path: 'ibooks-highlights/Test Book.md', basename: 'Test Book', parent: { path: 'ibooks-highlights' } };
+    const file = { path: '10 Sources/ibooks-dev/Test Book.md', basename: 'Test Book', parent: { path: '10 Sources/ibooks-dev' } };
     const data = 'some content\n%% keep-me %%\nUseful information to preserve between imports\n%% /keep-me %%\nmore content';
 
     await handler(file, data);
@@ -65,7 +65,11 @@ describe('quick-preview event', () => {
   });
 
   test('Should not save settings if file is a backup file', async () => {
-    const file = { path: 'ibooks-highlights/Test-Book-bk-12345.md', basename: 'Test-Book-bk-12345', parent: { path: 'ibooks-highlights' } };
+    const file = {
+      path: '10 Sources/ibooks-dev/Test-Book-bk-12345.md',
+      basename: 'Test-Book-bk-12345',
+      parent: { path: '10 Sources/ibooks-dev' },
+    };
     const data = '%% keep-me %%\nUseful information to preserve between imports\n%% /keep-me %%';
 
     await handler(file, data);
@@ -74,7 +78,7 @@ describe('quick-preview event', () => {
   });
 
   test('Should not save settings if no Keep Me section is extracted', async () => {
-    const file = { path: 'ibooks-highlights/Test.md', basename: 'Test' };
+    const file = { path: '10 Sources/ibooks-dev/Test.md', basename: 'Test' };
     const data = 'content without Keep Me section delimiters';
 
     await handler(file, data);

--- a/test/mocks/mockedDatabaseSetup.ts
+++ b/test/mocks/mockedDatabaseSetup.ts
@@ -27,6 +27,7 @@ export const createTestDatabaseAndTables = () => {
     ZLASTOPENDATE REAL,
     ZDATEFINISHED REAL,
     ZCOVERURL TEXT,
+    ZPATH TEXT,
     ZPURCHASEDATE REAL
   );
     
@@ -53,8 +54,8 @@ interface IAnnotationFromDb extends IAnnotation {
 
 export const insertTestData = (db: any) => {
   const insertBook = db.prepare(`
-    INSERT INTO ZBKLIBRARYASSET (ZASSETID, ZTITLE, ZAUTHOR, ZGENRE, ZLANGUAGE, ZLASTOPENDATE, ZDATEFINISHED, ZCOVERURL, ZPURCHASEDATE)
-    VALUES (@bookId, @bookTitle, @bookAuthor, @bookGenre, @bookLanguage, @bookLastOpenedDate, @bookFinishedDate, @bookCoverUrl, @ZPURCHASEDATE);
+    INSERT INTO ZBKLIBRARYASSET (ZASSETID, ZTITLE, ZAUTHOR, ZGENRE, ZLANGUAGE, ZLASTOPENDATE, ZDATEFINISHED, ZCOVERURL, ZPATH, ZPURCHASEDATE)
+    VALUES (@bookId, @bookTitle, @bookAuthor, @bookGenre, @bookLanguage, @bookLastOpenedDate, @bookFinishedDate, @bookCoverUrl, @bookPath, @ZPURCHASEDATE);
   `);
 
   const insertAnnotation = db.prepare(`
@@ -66,7 +67,7 @@ export const insertTestData = (db: any) => {
 
   const insertBooksTransaction = db.transaction((booksData: IBook[]) => {
     for (const book of booksData) {
-      const { bookId, bookTitle, bookAuthor, bookGenre, bookLanguage, bookLastOpenedDate, bookFinishedDate, bookCoverUrl } = book;
+      const { bookId, bookTitle, bookAuthor, bookGenre, bookLanguage, bookLastOpenedDate, bookFinishedDate, bookCoverUrl, bookPath } = book;
 
       if (bookTitle !== 'Non-Purchased Book') {
         insertBook.run({
@@ -78,6 +79,7 @@ export const insertTestData = (db: any) => {
           bookLastOpenedDate,
           bookFinishedDate,
           bookCoverUrl,
+          bookPath: bookPath || '',
           ZPURCHASEDATE: bookLastOpenedDate,
         });
       } else {
@@ -90,6 +92,7 @@ export const insertTestData = (db: any) => {
           bookLastOpenedDate,
           bookFinishedDate,
           bookCoverUrl,
+          bookPath: bookPath || '',
           ZPURCHASEDATE: null,
         });
       }

--- a/test/mocks/obsidian.ts
+++ b/test/mocks/obsidian.ts
@@ -12,6 +12,8 @@ export class Plugin {
   addRibbonIcon() {}
   addCommand() {}
   addSettingTab() {}
+  registerView() {}
+  registerMarkdownCodeBlockProcessor() {}
   loadData() {
     return {};
   }
@@ -36,6 +38,31 @@ export function setIcon(): void {}
 export class App {}
 export class PluginSettingTab {}
 export class Setting {}
+
+export class ItemView {
+  app: App = new App();
+  contentEl = {
+    empty() {},
+    createDiv() {
+      return this;
+    },
+    addClass() {},
+    toggleClass() {},
+  };
+  leaf: unknown;
+
+  constructor(leaf?: unknown) {
+    this.leaf = leaf;
+  }
+}
+
+export class WorkspaceLeaf {}
+
+export const Platform = {
+  isMobile: false,
+  isPhone: false,
+  isTablet: false,
+};
 
 export class Modal {
   app: App;

--- a/test/pluginInfo.spec.ts
+++ b/test/pluginInfo.spec.ts
@@ -30,13 +30,13 @@ describe('Plugin information', () => {
   });
 
   test('Check plugin id, name and description', ({ manifest }) => {
-    expect(manifest.id).toEqual('apple-books-import-highlights');
-    expect(manifest.name).toEqual('Apple Books - Import Highlights');
-    expect(manifest.description).toEqual('Import your Apple Books highlights and notes to Obsidian.');
+    expect(manifest.id).toEqual('apple-books-knowledge-cards');
+    expect(manifest.name).toEqual('Apple Books Knowledge Cards');
+    expect(manifest.description).toEqual('Import Apple Books highlights as structured notes and knowledge cards.');
   });
 
   test('Check author information', ({ manifest }) => {
     expect(packageJson.author).toEqual(manifest.author);
-    expect(manifest.authorUrl).toEqual('https://github.com/bandantonio');
+    expect(manifest.authorUrl).toEqual('https://github.com/jinjideweima');
   });
 });

--- a/test/unit/main.spec.ts
+++ b/test/unit/main.spec.ts
@@ -111,7 +111,7 @@ describe('IBookHighlightsPlugin', () => {
 
       expect(backupAllHighlightsMock).toHaveBeenCalled();
       expect(importHighlightsMock).toHaveBeenCalledWith(plugin.vault, expect.anything(), 'modify');
-      expect(NoticeMock).toHaveBeenCalledWith('Apple Books highlights imported successfully');
+      expect(NoticeMock).toHaveBeenCalledWith('Apple Books 摘录导入成功');
     });
 
     test('Should show OverwriteBookModal on start without creating a backup when backup is disabled', async () => {
@@ -150,7 +150,7 @@ describe('IBookHighlightsPlugin', () => {
       await plugin.onload();
       await onLayoutReadyPromise;
 
-      expect(NoticeMock).toHaveBeenCalledWith('Apple Books highlights imported successfully');
+      expect(NoticeMock).toHaveBeenCalledWith('Apple Books 摘录导入成功');
     });
 
     test('Should show error notice if import fails on start and backup is enabled', async () => {
@@ -169,7 +169,7 @@ describe('IBookHighlightsPlugin', () => {
 
       expect(backupAllHighlightsMock).toHaveBeenCalled();
       expect(importHighlightsMock).toHaveBeenCalledWith(plugin.vault, expect.anything(), 'modify');
-      expect(NoticeMock).toHaveBeenCalledWith('[Apple Books Test Mock]:\nError importing highlights. Check console for details (⌥ ⌘ I)', 0);
+      expect(NoticeMock).toHaveBeenCalledWith('[Apple Books Test Mock]:\n导入摘录失败，请打开开发者控制台查看详情（⌥ ⌘ I）', 0);
     });
   });
   describe('Ribbon action import', () => {
@@ -181,7 +181,7 @@ describe('IBookHighlightsPlugin', () => {
       await callback({} as any);
       expect(backupAllHighlightsMock).toHaveBeenCalled();
       expect(importHighlightsMock).toHaveBeenCalled();
-      expect(NoticeMock).toHaveBeenCalledWith('Apple Books highlights imported successfully');
+      expect(NoticeMock).toHaveBeenCalledWith('Apple Books 摘录导入成功');
     });
 
     test('Should throw error notice if import fails on ribbon icon click if backup setting is enabled', async () => {
@@ -192,7 +192,7 @@ describe('IBookHighlightsPlugin', () => {
       await callback({} as any);
       expect(backupAllHighlightsMock).toHaveBeenCalled();
       expect(importHighlightsMock).toHaveBeenCalled();
-      expect(NoticeMock).toHaveBeenCalledWith('[Apple Books Test Mock]:\nError importing highlights. Check console for details (⌥ ⌘ I)', 0);
+      expect(NoticeMock).toHaveBeenCalledWith('[Apple Books Test Mock]:\n导入摘录失败，请打开开发者控制台查看详情（⌥ ⌘ I）', 0);
     });
 
     test('Should show OverwriteBookModal on ribbon icon click if backup setting is disabled', async () => {
@@ -230,7 +230,7 @@ describe('IBookHighlightsPlugin', () => {
       await commandCallback({} as any);
       expect(backupAllHighlightsMock).toHaveBeenCalled();
       expect(importHighlightsMock).toHaveBeenCalled();
-      expect(NoticeMock).toHaveBeenCalledWith('[Apple Books Test Mock]:\nError importing highlights. Check console for details (⌥ ⌘ I)', 0);
+      expect(NoticeMock).toHaveBeenCalledWith('[Apple Books Test Mock]:\n导入摘录失败，请打开开发者控制台查看详情（⌥ ⌘ I）', 0);
     });
 
     test('Should show OverwriteBookModal on addImportAllBooksCommand if backup setting is disabled', async () => {
@@ -272,7 +272,7 @@ describe('IBookHighlightsPlugin', () => {
 
       const commandCallback = mockAddCommand.mock.calls[1][0].callback;
       await commandCallback({} as any);
-      expect(NoticeMock).toHaveBeenCalledWith('[Apple Books Test Mock]:\nError importing highlights. Check console for details (⌥ ⌘ I)', 0);
+      expect(NoticeMock).toHaveBeenCalledWith('[Apple Books Test Mock]:\n导入摘录失败，请打开开发者控制台查看详情（⌥ ⌘ I）', 0);
     });
 
     test.todo('Trigger import via keyboard shortcut/command palette');

--- a/test/unit/settings/settings.spec.ts
+++ b/test/unit/settings/settings.spec.ts
@@ -19,7 +19,7 @@ describe('Default settings', () => {
   });
 
   test('Should check that default settings have the expected default values', () => {
-    expect(defaultPluginSettings.highlightsFolder).toBe('ibooks-highlights');
+    expect(defaultPluginSettings.highlightsFolder).toBe('10 Sources/ibooks-dev');
     expect(defaultPluginSettings.backup).toBe(false);
     expect(defaultPluginSettings.importOnStart).toBe(false);
     expect(defaultPluginSettings.highlightsSortingCriterion).toBe('creationDateOldToNew');
@@ -34,11 +34,8 @@ describe('Default settings', () => {
       '{{{bookAuthor}}}',
       '{{annotations.length}}',
       '{{#each annotations}}',
-      '{{#if chapter}}{{{chapter}}}{{else}}N/A{{/if}}',
-      '{{#if contextualText}}{{{contextualText}}}{{else}}N/A{{/if}}',
-      '{{{highlight}}}',
-      '{{#if note}}{{{note}}}{{else}}N/A{{/if}}',
-      '{{#if highlightLocation}}[Apple Books Highlight Link](ibooks://assetid/{{../bookId}}#{{highlightLocation}}){{else}}N/A{{/if}}',
+      '{{displayIndex @index}}',
+      'book_id: {{bookId}}',
       '{{/each}}',
     ];
 


### PR DESCRIPTION
## 功能概述

为插件新增摘录卡片系统和阅读仪表盘，将 Apple Books 高亮摘录转化为结构化的知识卡片。

## 新增功能

- 🃏 **摘录卡片墙**：以卡片形式展示所有摘录，支持按书名、作者、章节、颜色筛选
- 📊 **阅读仪表盘**：统计书籍数量、摘录数量、收藏数、想法数，支持随机回顾
- 📖 **EPUB 章节推断**：从 epub 文件自动补全摘录所属章节
- ⭐ **收藏与笔记**：可对每条摘录标记收藏、编辑本地笔记

## 改动说明

- `src/types` — 新增卡片和仪表盘相关数据类型
- `src/modules/epubChapters` — EPUB 解析引擎（ZIP + 目录解析）
- `src/modules/highlightCards` — 卡片文件生成逻辑
- `src/modules/highlightRepository` — 卡片读取与状态更新
- `src/views/` — 卡片墙渲染器、视图、仪表盘视图
- `main.ts` / `settings` — 插件入口集成

## 测试

- 全部 144 个已有测试通过
- 新功能测试待补充（见 #TODO）
